### PR TITLE
Migration mwerneburg/CivOne

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,8 @@ All documentation should be written in English (even if the prompt is in another
 - Avoid service locator pattern
 - Use constructor injection
 - Follow SOLID principles
-- Prefer interfaces for services
+- Prefer interfaces and services
+- Prefer Factory pattern instead of new for services.
 - Keep methods small and focused
 - Prefer 'new()' expression instead of fully qualified new syntax 
 
@@ -18,3 +19,66 @@ All documentation should be written in English (even if the prompt is in another
 
 * Debounce Service with DebounceServiceFactory and IDebounceService
 * Random Number Generator with IRandomNumberGenerator and RandomNumberGeneratorFactory
+
+
+
+
+
+## Cavemen
+
+You are a caveman compression expert. Aggressively remove all stop words and grammatical scaffolding while preserving meaning.
+
+CORE STRATEGY:
+1. Remove articles, auxiliary verbs, and redundant words. Keep only content words that carry semantic meaning.
+2. Use simple, common words. If there's a simpler word, use it. Think like a caveman.
+
+ALWAYS REMOVE:
+- Articles: a, an, the
+- Auxiliary verbs: is, are, was, were, am, be, been, being, have, has, had, do, does, did
+- Common prepositions when meaning stays clear: of, for, to, in, on, at
+- Pronouns when context is clear: it, this, that, these, those
+- Pure intensifiers: very, quite, rather, somewhat, really, extremely
+
+ALWAYS KEEP:
+- All nouns (people, places, things, concepts)
+- All main verbs (actions, not auxiliaries)
+- All adjectives that add meaning
+- All numbers and quantifiers (at least, approximately, more than, 15, many)
+- Uncertainty qualifiers (what sounded like, appears to be, seems, might)
+- Critical prepositions that change meaning (from, with, without, stuck to)
+- Time/frequency words (every Tuesday, weekly, daily, always, never)
+- Names, titles (Dr., Mr., Senator)
+- Technical terms and domain-specific language
+
+BE SMART ABOUT:
+- Keep prepositions when they define relationships: "made from wood" (keep from), "system for processing" (remove for)
+- Keep "in/on/at" when they specify location/position, remove when just grammatical
+- Remove "is/are/was/were" unless part of passive voice that matters
+- Keep negations (not, no, never, without)
+
+EXAMPLES:
+
+"Caveman Compression is a semantic compression method for LLM contexts"
+→ "Caveman Compression semantic compression method LLM contexts."
+(Remove: is, a, for)
+
+"It removes predictable grammar while preserving the unpredictable content"
+→ "Removes predictable grammar preserving unpredictable content."
+(Remove: It, the, while → keep main meaning)
+
+"The system was designed to process data efficiently"
+→ "System designed process data efficiently."
+(Remove: The, was, to)
+
+"There were at least 20 people"
+→ "At least 20 people."
+(Keep: at least - quantifier matters)
+
+"Made from wood and metal"
+→ "Made from wood and metal."
+(Keep: from - shows material relationship)
+
+Output ONLY the caveman compressed text, nothing else.
+
+TEXT TO COMPRESS:
+{text}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,3 +12,9 @@ All documentation should be written in English (even if the prompt is in another
 - Follow SOLID principles
 - Prefer interfaces for services
 - Keep methods small and focused
+- Prefer 'new()' expression instead of fully qualified new syntax 
+
+## Existing useful code
+
+* Debounce Service with DebounceServiceFactory and IDebounceService
+* Random Number Generator with IRandomNumberGenerator and RandomNumberGeneratorFactory

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,10 @@
-# C# Coding Guidelines
+# CoPilot Instructions
+
+## Documentation
+
+All documentation should be written in English (even if the prompt is in another language). Use clear and concise language to explain concepts, code, and processes. Avoid jargon and technical terms unless necessary, and provide definitions when they are used.
+
+## C# Coding Guidelines
 
 - Always use dependency injection. Never instantiate dependencies manually with new.
 - Avoid service locator pattern

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -48,7 +48,7 @@
 			"request": "launch",
 			"preLaunchTask": "build",
 			"program": "${workspaceRoot}/runtime/sdl/bin/Debug/net9.0/CivOne.SDL.dll",
-			"args": ["--seed", "32768", "--skip-credits", "--skip-intro", "--no-sound", "--no-data-check", "--load-slot", "d1"],
+			"args": ["--seed", "32768", "--skip-credits", "--skip-intro", "--no-sound", "--no-data-check", "--load-slot", "c5"],
 			"cwd": "${workspaceRoot}",
 			"stopAtEntry": false,
 			"console": "internalConsole",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,7 +43,67 @@
 			"internalConsoleOptions": "openOnSessionStart"
 		},
 		{
-			"name": "Quick Load Game Slot 0",
+			"name": "Quick Load Game Slot C0",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			"program": "${workspaceRoot}/runtime/sdl/bin/Debug/net9.0/CivOne.SDL.dll",
+			"args": ["--seed", "32768", "--skip-credits", "--skip-intro", "--no-sound", "--no-data-check", "--load-slot", "c0"],
+			"cwd": "${workspaceRoot}",
+			"stopAtEntry": false,
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
+			"name": "Quick Load Game Slot C1",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			"program": "${workspaceRoot}/runtime/sdl/bin/Debug/net9.0/CivOne.SDL.dll",
+			"args": ["--seed", "32768", "--skip-credits", "--skip-intro", "--no-sound", "--no-data-check", "--load-slot", "c1"],
+			"cwd": "${workspaceRoot}",
+			"stopAtEntry": false,
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
+			"name": "Quick Load Game Slot C2",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			"program": "${workspaceRoot}/runtime/sdl/bin/Debug/net9.0/CivOne.SDL.dll",
+			"args": ["--seed", "32768", "--skip-credits", "--skip-intro", "--no-sound", "--no-data-check", "--load-slot", "c2"],
+			"cwd": "${workspaceRoot}",
+			"stopAtEntry": false,
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
+			"name": "Quick Load Game Slot C3",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			"program": "${workspaceRoot}/runtime/sdl/bin/Debug/net9.0/CivOne.SDL.dll",
+			"args": ["--seed", "32768", "--skip-credits", "--skip-intro", "--no-sound", "--no-data-check", "--load-slot", "c3"],
+			"cwd": "${workspaceRoot}",
+			"stopAtEntry": false,
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
+			"name": "Quick Load Game Slot C4",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build",
+			"program": "${workspaceRoot}/runtime/sdl/bin/Debug/net9.0/CivOne.SDL.dll",
+			"args": ["--seed", "32768", "--skip-credits", "--skip-intro", "--no-sound", "--no-data-check", "--load-slot", "c4"],
+			"cwd": "${workspaceRoot}",
+			"stopAtEntry": false,
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
+			"name": "Quick Load Game Slot C5",
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build",
@@ -55,7 +115,7 @@
 			"internalConsoleOptions": "openOnSessionStart"
 		},
 		{
-			"name": "Quick Load Game YAML",
+			"name": "Quick Load Game YAML .saves/savegame_0.cos",
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
 	// Controls whether the editor should automatically close quotes after opening them.
 	"editor.autoClosingQuotes": "never",
 	// Controls whether the editor should automatically surround selections when typing quotes or brackets.
-	"editor.autoSurround": "never"
+	"editor.autoSurround": "never",
+	"chat.tools.terminal.autoApprove": {
+		"dotnet test": true
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,8 +16,5 @@
 	// Controls whether the editor should automatically close quotes after opening them.
 	"editor.autoClosingQuotes": "never",
 	// Controls whether the editor should automatically surround selections when typing quotes or brackets.
-	"editor.autoSurround": "never",
-	"chat.tools.terminal.autoApprove": {
-		"dotnet test": true
-	}
+	"editor.autoSurround": "never"
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,10 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
-* Added `IsAtWarWith(...)`, `DeclareWar(...)`, `MakePeace(...)` method to `Player` to check runtime war state without consulting legacy diplomacy flags.
+* Migration from [`mwerneburg/CivOne`](https://github.com/mwerneburg/CivOne): `IsAtWarWith(...)`, `DeclareWar(...)`, `MakePeace(...)` method to `Player` to check runtime war state without consulting legacy diplomacy flags.
   * These methods are not yet integrated into gameplay and are not yet used for any game logic. They are intended to be used in future diplomacy mechanics implementation.
+* Migration from [`mwerneburg/CivOne`](https://github.com/mwerneburg/CivOne): war-time trade route purge now uses the existing city `TradingCities` model.
+  * On `DeclareWar(...)`, trade links between both parties are removed bilaterally; third-party links remain unchanged.
 * Fix: `Alt+Enter` fullscreen toggle now persists the new state to the profile.
 * Feature: Window placement persistence improved.
   * Window position is now stored in the profile and restored on startup.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,16 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
+* Feature: Ongoing migration from [`mwerneburg/CivOne`](https://github.com/mwerneburg/CivOne) (single consolidated entry; extend sub-points over time)
+  * Migrated: `CivilizationIdentity` save/load bitmask fix in `SaveDataAdapter` (bit-shift mapping aligned with source fork behavior).
+  * Migrated: macOS SDL native resolver registration in startup (`Program`).
+    * Adds explicit fallback search paths for SDL2 framework/Homebrew installs on macOS.
+    * Reduces manual environment setup requirements for native SDL loading.
+  * Migrated: map centering and horizontal wrapping fix in `GameMap.CenterOnPoint(...)`.
+    * Replaced hard-coded X offset with dynamic viewport-based centering.
+    * Added explicit X wrapping for negative/overflow values.
+    * Replaced hard-coded Y clamp window with `_tilesY`-based clamp.
+  * Next migration additions come here next!
 * Feature: Extended fixed-layout UI behavior in `Aspect Ratio = Expand` mode to avoid stretching and keep screens centered.
   * `Palace`, `CityView`, `Conquest`, `Civilopedia` now renders as centered 320x200 content instead of stretching across the expanded canvas.
   * All report screens (Demographics, City Status, Attitude Survey, Science Report, Trade Report) are now rendered as centered 320x200 content instead of stretching across the expanded canvas.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@ I did not browse all issues on github at first, so I did not recognize that some
     * Expand default canvas fallback changed to `640x360` when no explicit Expand size is configured.
     * Sub-canvas bytemaps in Expand mode now keep integer scaling and centered placement.
     * Expand canvas hard cap raised from `512x384` to `2560x1600`.
+    * Allowed Expand ranges updated to `320..7680` and `200..4320`.
   * Next migration additions come here next!
 * Feature: Extended fixed-layout UI behavior in `Aspect Ratio = Expand` mode to avoid stretching and keep screens centered.
   * `Palace`, `CityView`, `Conquest`, `Civilopedia` now renders as centered 320x200 content instead of stretching across the expanded canvas.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ I did not browse all issues on github at first, so I did not recognize that some
 ## History
 
 * Fix: `Alt+Enter` fullscreen toggle now persists the new state to the profile.
+* Feature: Window placement persistence improved.
+  * Window position is now stored in the profile and restored on startup.
+  * On restore, position is validated against currently available displays; invalid/off-screen positions fall back to top-left (`0,0`).
+  * Window maximized state is persisted and restored (windowed mode).
+  * Refactor: window placement handling in `GameWindow.Update(...)` was split into smaller helper methods with clearer names.
 * Feature: Added multiple standard screen and window resolutions to the setup menu (e.g. `1920x1080`, `2560x1440`, `3840x2160`).
   * Added preset options for "Window Size" and "Expand Size" settings in the setup menu.
   * Updated the "Expand Size" setting to allow for larger resolutions up to `7680x4320` (8K UHD).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
+* Fix: `Alt+Enter` fullscreen toggle now persists the new state to the profile.
+* Feature: Added multiple standard screen and window resolutions to the setup menu (e.g. `1920x1080`, `2560x1440`, `3840x2160`).
+  * Added preset options for "Window Size" and "Expand Size" settings in the setup menu.
+  * Updated the "Expand Size" setting to allow for larger resolutions up to `7680x4320` (8K UHD).
+  * Use "Auto" option for "Expand Size" to stretch the canvas to fill the window, otherwise the game will render at the selected resolution and may be cropped if the window is smaller.
 * Feature: Ongoing migration from [`mwerneburg/CivOne`](https://github.com/mwerneburg/CivOne) (single consolidated entry; extend sub-points over time)
   * Migrated: `CivilizationIdentity` save/load bitmask fix in `SaveDataAdapter` (bit-shift mapping aligned with source fork behavior).
   * Migrated: macOS SDL native resolver registration in startup (`Program`).
@@ -22,6 +27,13 @@ I did not browse all issues on github at first, so I did not recognize that some
     * Added horizontal X-axis wrapping during connectivity checks.
     * Reduces stack overflow risk on larger maps.
     * Implementation extracted to `ContinentTraversalDelegate` for better separation of concerns and testability.
+  * Migrated: Expand settings load fix in `Settings`.
+    * `ExpandWidth`/`ExpandHeight` now load into dedicated fields instead of `_scale`.
+    * Allowed Expand ranges updated to `320..2560` and `200..1600`.
+  * Migrated: Expand canvas/scaling adjustments in `GameWindow.Graphics`.
+    * Expand default canvas fallback changed to `640x360` when no explicit Expand size is configured.
+    * Sub-canvas bytemaps in Expand mode now keep integer scaling and centered placement.
+    * Expand canvas hard cap raised from `512x384` to `2560x1600`.
   * Next migration additions come here next!
 * Feature: Extended fixed-layout UI behavior in `Aspect Ratio = Expand` mode to avoid stretching and keep screens centered.
   * `Palace`, `CityView`, `Conquest`, `Civilopedia` now renders as centered 320x200 content instead of stretching across the expanded canvas.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,10 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
-* Migration from [`mwerneburg/CivOne`](https://github.com/mwerneburg/CivOne): `IsAtWarWith(...)`, `DeclareWar(...)`, `MakePeace(...)` method to `Player` to check runtime war state without consulting legacy diplomacy flags.
+* Migration from [`mwerneburg/CivOne`](https://github.com/mwerneburg/CivOne): added `IsAtWar(Player)` and `SetAtWar(...)` methods to `Player` to check runtime war state without consulting legacy diplomacy flags.
   * These methods are not yet integrated into gameplay and are not yet used for any game logic. They are intended to be used in future diplomacy mechanics implementation.
 * Migration from [`mwerneburg/CivOne`](https://github.com/mwerneburg/CivOne): war-time trade route purge now uses the existing city `TradingCities` model.
-  * On `DeclareWar(...)`, trade links between both parties are removed bilaterally; third-party links remain unchanged.
+  * On `SetAtWar(...)`, trade links between both parties are removed bilaterally; third-party links remain unchanged.
 * Fix: `Alt+Enter` fullscreen toggle now persists the new state to the profile.
 * Feature: Window placement persistence improved.
   * Window position is now stored in the profile and restored on startup.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
+* Added `IsAtWarWith(...)`, `DeclareWar(...)`, `MakePeace(...)` method to `Player` to check runtime war state without consulting legacy diplomacy flags.
+  * These methods are not yet integrated into gameplay and are not yet used for any game logic. They are intended to be used in future diplomacy mechanics implementation.
 * Fix: `Alt+Enter` fullscreen toggle now persists the new state to the profile.
 * Feature: Window placement persistence improved.
   * Window position is now stored in the profile and restored on startup.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,11 @@ I did not browse all issues on github at first, so I did not recognize that some
     * Replaced hard-coded Y clamp window with `_tilesY`-based clamp.
   * Migrated: map generation grassland assignment fix in `Map.Generate` climate adjustment pass.
     * Ensures transformed `Terrain.Plains` tiles are assigned back to `_tiles[x, y]`.
+  * Migrated: continent/ocean counting flood-fill in `Map.Generate`.
+    * Replaced recursive traversal with iterative queue-based traversal.
+    * Added horizontal X-axis wrapping during connectivity checks.
+    * Reduces stack overflow risk on larger maps.
+    * Implementation extracted to `ContinentTraversalDelegate` for better separation of concerns and testability.
   * Next migration additions come here next!
 * Feature: Extended fixed-layout UI behavior in `Aspect Ratio = Expand` mode to avoid stretching and keep screens centered.
   * `Palace`, `CityView`, `Conquest`, `Civilopedia` now renders as centered 320x200 content instead of stretching across the expanded canvas.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ I did not browse all issues on github at first, so I did not recognize that some
     * Replaced hard-coded X offset with dynamic viewport-based centering.
     * Added explicit X wrapping for negative/overflow values.
     * Replaced hard-coded Y clamp window with `_tilesY`-based clamp.
+  * Migrated: map generation grassland assignment fix in `Map.Generate` climate adjustment pass.
+    * Ensures transformed `Terrain.Plains` tiles are assigned back to `_tiles[x, y]`.
   * Next migration additions come here next!
 * Feature: Extended fixed-layout UI behavior in `Aspect Ratio = Expand` mode to avoid stretching and keep screens centered.
   * `Palace`, `CityView`, `Conquest`, `Civilopedia` now renders as centered 320x200 content instead of stretching across the expanded canvas.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ brew install sdl2
 
 Homebrew installs SDL2 system-wide, and the dynamic library will be available automatically at runtime.
 
+The SDL loader also includes a macOS native resolver with fallback search paths.
+The resolver checks `/Library/Frameworks/SDL2.framework/Versions/Current/SDL2` first.
+The resolver then checks Homebrew library paths in `/opt/homebrew/lib` and `/usr/local/lib`.
+This reduces manual setup and usually avoids setting `DYLD_LIBRARY_PATH`.
+This behavior applies only on macOS.
+
 ### Troubleshooting
 
 * Ensure the SDL2 **native library** is installed, not only C# bindings.

--- a/README.md
+++ b/README.md
@@ -361,6 +361,20 @@ Alternatively, run individual cleanup tasks in VS Code:
 * `clean` – Runs `dotnet clean`
 * `clean-coverage-folders` – Removes `TestResults/` and `CoverageReport/` directories
 
+## FAQ
+
+### The screen content is cut off after resizing the window
+
+This happens when **Aspect Ratio** is set to `Expand` and a fixed window size was saved.
+In `Expand` mode the game renders exactly as many tiles as fit the current window.
+When the window is later made smaller, the rendered area stays the same size but no longer fits inside the window, so parts of the screen (e.g. the top or sides) are cropped.
+
+To fix this, resize the window to match the size the game was configured for, or change the **Aspect Ratio** setting to `Fixed`, `Scaled`, or `ScaledFixed`.
+Those modes always scale or letterbox the fixed 320x200 game surface to fit any window size.
+
+If you want to use `Expand` mode, make sure to use `Auto` for the Expand size in the settings, which allows the game to automatically adjust the rendered area to fit the window size.
+
+
 ## Changes (Log)
 
 See [CHANGES.md](CHANGES.md) for a detailed list of changes and updates.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ This screen allows to change additional modification options for the game.
 | AutoSave format | Choose whether autosaves prefer legacy `SVE` output with automatic `COS` fallback or always write `COS`. |
 | Save cast behavior | Select whether save/load casts use checked conversion or the legacy unchecked mode. |
 | (Gbm) Use smart PathFinding for "goto" | Enable smart pathfinding for unit movement. |
+| (Gbm) Use smart pathfinding for computer players | Enable smart pathfinding for computer controlled units only. Disable to use legacy AI movement behavior. |
 | (Gbm) Use auto-settlers-cheat | Enable automatic settlers (cheat) to place settlers automatically. |
 | (Gbm) Use fast river movement | Movements on rivers behave like roads (faster movement). |
 | (Gbm) No movement penalty for sea units in city | Sea units suffer no movement penalty when in a city. |

--- a/runtime/sdl/src/GameWindow.Graphics.cs
+++ b/runtime/sdl/src/GameWindow.Graphics.cs
@@ -22,9 +22,11 @@ namespace CivOne
 		{
 			get
 			{
-				if (Settings.AspectRatio != AspectRatio.Expand || Settings.ExpandWidth == -1 || Settings.ExpandHeight == -1)
+				if (Settings.AspectRatio != AspectRatio.Expand)
 					return new Size(320, 200);
-				return new Size(Settings.ExpandWidth, Settings.ExpandHeight);
+				if (Settings.ExpandWidth > 0 && Settings.ExpandHeight > 0)
+					return new Size(Settings.ExpandWidth, Settings.ExpandHeight);
+				return new Size(320, 200);
 			}
 		}
 
@@ -72,7 +74,7 @@ namespace CivOne
 
 		private Size SetCanvasSize()
 		{
-			if (Settings.AspectRatio != AspectRatio.Expand || (ScaleX < 1 || ScaleY < 1))
+			if (Settings.AspectRatio != AspectRatio.Expand)
 			{
 				return DefaultCanvasSize;
 			}
@@ -80,13 +82,15 @@ namespace CivOne
 			int cw = ClientRectangle.Width, ch = ClientRectangle.Height;
 			int scale = new int[] { (cw - (cw % 320)) / 320, (ch - (ch % 200)) / 200 }.Min();
 
-			if (Settings.ExpandWidth != -1 && Settings.ExpandHeight != -1)
+			bool hasExplicitExpandSize = Settings.ExpandWidth > 0 && Settings.ExpandHeight > 0;
+			if (hasExplicitExpandSize)
 			{
 				cw = Settings.ExpandWidth;
 				ch = Settings.ExpandHeight;
 			}
 			else
 			{
+				if (scale < 1) scale = 1;
 				cw /= scale;
 				ch /= scale;
 			}
@@ -95,19 +99,21 @@ namespace CivOne
 			cw -= (cw % 8);
 			ch -= (ch % 8);
 
-			// Set maximum bounds to 512x384, the maximum logical boundaries 
-			// according this this table: https://github.com/SWY1985/CivOne/wiki/Settings#expand-experimental
-			if (cw > 512) cw = 512;
-			if (ch > 384) ch = 384;
+			// CW: Keep auto-expand conservative for stability, but allow larger explicit user values.
+			// Original: https://github.com/Solen1985/CivOne/wiki/Settings#expand-experimental
+			int maxWidth  = hasExplicitExpandSize ? Settings.MaxExpandWidth  : Settings.AutoExpandMaxWidth;
+			int maxHeight = hasExplicitExpandSize ? Settings.MaxExpandHeight : Settings.AutoExpandMaxHeight;
+			if (cw > maxWidth) cw = maxWidth;
+			if (ch > maxHeight) ch = maxHeight;
 
 			return new Size(cw, ch);
 		}
 
-		private static int InitialCanvasWidth => DefaultCanvasSize.Width;
-		private static int InitialCanvasHeight => DefaultCanvasSize.Height;
+		private static int InitialCanvasWidth => 320;
+		private static int InitialCanvasHeight => 200;
 
-		private static int InitialWidth => InitialCanvasWidth * Settings.Scale;
-		private static int InitialHeight => InitialCanvasHeight * Settings.Scale;
+		private static int InitialWidth => Settings.WindowWidth > 0 ? Settings.WindowWidth : InitialCanvasWidth * Settings.Scale;
+		private static int InitialHeight => Settings.WindowHeight > 0 ? Settings.WindowHeight : InitialCanvasHeight * Settings.Scale;
 
 		private Size ClientRectangle => new Size(Width, Height);
 
@@ -132,8 +138,8 @@ namespace CivOne
 						int scaleX = (ClientRectangle.Width - (ClientRectangle.Width % cw)) / cw;
 						int scaleY = (ClientRectangle.Height - (ClientRectangle.Height % ch)) / ch;
 						if (scaleX > scaleY)
-							return scaleY;
-						return scaleX;
+								return scaleY < 1 ? 1 : scaleY;
+							return scaleX < 1 ? 1 : scaleX;
 					default:
 						return (ClientRectangle.Width - (ClientRectangle.Width % cw)) / cw;
 				}
@@ -156,8 +162,8 @@ namespace CivOne
 						int scaleX = (ClientRectangle.Width - (ClientRectangle.Width % cw)) / cw;
 						int scaleY = (ClientRectangle.Height - (ClientRectangle.Height % ch)) / ch;
 						if (scaleY > scaleX)
-							return scaleX;
-						return scaleY;
+								return scaleX < 1 ? 1 : scaleX;
+							return scaleY < 1 ? 1 : scaleY;
 					default:
 						return (ClientRectangle.Height - (ClientRectangle.Height % ch)) / ch;
 				}

--- a/runtime/sdl/src/GameWindow.cs
+++ b/runtime/sdl/src/GameWindow.cs
@@ -29,6 +29,8 @@ namespace CivOne
 		private bool _settingsFullscreen = Settings.FullScreen;
 
 		private int _settingsScale = Settings.Scale;
+		private int _settingsWindowWidth = Settings.WindowWidth;
+		private int _settingsWindowHeight = Settings.WindowHeight;
 
 		private void Load(object sender, EventArgs args)
 		{
@@ -45,6 +47,18 @@ namespace CivOne
 			if (_settingsFullscreen != Settings.FullScreen)
 			{
 				_settingsFullscreen = Settings.FullScreen;
+				if (_settingsFullscreen)
+				{
+					// Save the display resolution so WindowSize knows the screen dimensions
+					var displaySize = GetDisplaySize();
+					if (displaySize.Width > 0 && displaySize.Height > 0)
+					{
+						_settingsWindowWidth  = displaySize.Width;
+						_settingsWindowHeight = displaySize.Height;
+						Settings.WindowWidth  = displaySize.Width;
+						Settings.WindowHeight = displaySize.Height;
+					}
+				}
 				Fullscreen = _settingsFullscreen;
 			}
 
@@ -52,6 +66,30 @@ namespace CivOne
 			{
 				ResetWindowScale();
 				_settingsScale = Settings.Scale;
+			}
+
+			if (!Settings.FullScreen)
+			{
+				int settW = Settings.WindowWidth;
+				int settH = Settings.WindowHeight;
+				int winW = Width;
+				int winH = Height;
+
+				// Settings changed externally (e.g. preset selected in Setup menu) → resize window immediately
+				if (settW > 0 && settH > 0 && (settW != _settingsWindowWidth || settH != _settingsWindowHeight) && (settW != winW || settH != winH))
+				{
+					SetWindowSize(settW, settH);
+					_settingsWindowWidth = settW;
+					_settingsWindowHeight = settH;
+				}
+				// Window was resized by user → persist to settings
+				else if (winW != _settingsWindowWidth || winH != _settingsWindowHeight)
+				{
+					_settingsWindowWidth = winW;
+					_settingsWindowHeight = winH;
+					Settings.WindowWidth = winW;
+					Settings.WindowHeight = winH;
+				}
 			}
 			
 			Runtime.CanvasSize = SetCanvasSize();
@@ -77,8 +115,8 @@ namespace CivOne
 		private PointF GetScaleF()
 		{
 			GetBorders(out int x1, out int y1, out int x2, out int y2);
-			float scaleX = (float)x2 / CanvasWidth;
-			float scaleY = (float)y2 / CanvasHeight;
+			float scaleX = (float)(x2 - x1) / CanvasWidth;
+			float scaleY = (float)(y2 - y1) / CanvasHeight;
 			if (Settings.AspectRatio == AspectRatio.ScaledFixed)
 			{
 				if (scaleX > scaleY) scaleX = scaleY;
@@ -87,29 +125,49 @@ namespace CivOne
 			return new PointF(scaleX, scaleY);
 		}
 
+		private Size InputSize
+		{
+			get
+			{
+				Bytemap topLayer = _runtime.Layers?.LastOrDefault();
+				if (topLayer != null && topLayer.Width > 0 && topLayer.Height > 0)
+				{
+					return new Size(topLayer.Width, topLayer.Height);
+				}
+				return new Size(CanvasWidth, CanvasHeight);
+			}
+		}
+
+		private static ScreenEventArgs CreateScreenEventArgs(int x, int y, MouseButton buttons)
+			=> buttons == MouseButton.None ? new ScreenEventArgs(x, y) : new ScreenEventArgs(x, y, buttons);
+
+		private static int ScaleToRange(int value, int sourceSize, int targetSize)
+			=> (int)((float)value * targetSize / sourceSize);
+
+		private static int Clamp(int value, int min, int max)
+		{
+			if (value < min) return min;
+			if (value > max) return max;
+			return value;
+		}
+
 		private ScreenEventArgs Transform(ScreenEventArgs args)
 		{
-			GetBorders(out int offsetX, out int offsetY, out _, out _);
-			int x = args.X - offsetX - (args.X % ScaleX);
-			int y = args.Y - offsetY - (args.Y % ScaleY);
-
-			switch (Settings.AspectRatio)
+			GetBorders(out int offsetX, out int offsetY, out int x2, out int y2);
+			int drawWidth = x2 - offsetX;
+			int drawHeight = y2 - offsetY;
+			Size inputSize = InputSize;
+			int localX = args.X - offsetX;
+			int localY = args.Y - offsetY;
+			if (drawWidth <= 0 || drawHeight <= 0)
 			{
-				case AspectRatio.Scaled:
-				case AspectRatio.ScaledFixed:
-					PointF scaleF = GetScaleF();
-					x = (int)((float)args.X / scaleF.X);
-					y = (int)((float)args.Y / scaleF.Y);
-					break;
-				default:
-					x /= ScaleX;
-					y /= ScaleY;
-					break;
+				return CreateScreenEventArgs(0, 0, args.Buttons);
 			}
 
-			if (args.Buttons == MouseButton.None)
-				return new ScreenEventArgs(x, y);
-			return new ScreenEventArgs(x, y, args.Buttons);
+			int x = Clamp(ScaleToRange(localX, drawWidth, inputSize.Width), 0, inputSize.Width - 1);
+			int y = Clamp(ScaleToRange(localY, drawHeight, inputSize.Height), 0, inputSize.Height - 1);
+
+			return CreateScreenEventArgs(x, y, args.Buttons);
 		}
 
 		private void KeyDown(object sender, KeyboardEventArgs args)
@@ -118,6 +176,7 @@ namespace CivOne
 			if (args.Modifier == KeyModifier.Alt && args.Key == Key.Enter)
 			{
 				Fullscreen = !Fullscreen;
+				Settings.FullScreen = Fullscreen;
 				return;
 			}
 			_runtime.InvokeKeyboardDown(args);
@@ -131,39 +190,37 @@ namespace CivOne
 
 		private void MouseMove(object sender, ScreenEventArgs args)
 		{
+			if (!IsInsideDrawArea(args)) return;
 			args = Transform(args);
 			if (args.X == _mouseX && args.Y == _mouseY) return;
 			_hasUpdate = true;
 			_mouseX = args.X;
 			_mouseY = args.Y;
-            args = AdjustMousePos(args);
 			_runtime.InvokeMouseMove(args);
 		}
 
 		private void MouseDown(object sender, ScreenEventArgs args)
         {
+			if (!IsInsideDrawArea(args)) return;
             args = Transform(args);
-            args = AdjustMousePos(args);
             _runtime.InvokeMouseDown(args);
         }
 
-        private ScreenEventArgs AdjustMousePos(ScreenEventArgs args)
-        {
-            if (Settings.AspectRatio == AspectRatio.ScaledFixed)
-            {
-                PointF scaleF = GetScaleF();
-                GetBorders(out int offsetX, out int offsetY, out _, out _);
-                args = new ScreenEventArgs(args.X - (int) ((float) offsetX / scaleF.X),
-                    args.Y - (int) ((float) offsetY / scaleF.Y), args.Buttons);
-            }
-
-            return args;
-        }
+		/// <summary>
+		/// Checks if the given mouse event is within the current draw area (i.e. not in letterbox borders).
+		/// This may be used to ignore mouse events that occur outside the draw area when the window is larger than the canvas (e.g. due to aspect ratio settings or user resizing).
+		/// </summary>
+		/// <param name="args">The mouse event arguments.</param>
+		private bool IsInsideDrawArea(ScreenEventArgs args)
+		{
+			GetBorders(out int x1, out int y1, out int x2, out int y2);
+			return args.X >= x1 && args.X < x2 && args.Y >= y1 && args.Y < y2;
+		}
 
         private void MouseUp(object sender, ScreenEventArgs args)
 		{
+            if (!IsInsideDrawArea(args)) return;
             args = Transform(args);
-            args = AdjustMousePos(args);
 			_runtime.InvokeMouseUp(args);
 		}
 

--- a/runtime/sdl/src/GameWindow.cs
+++ b/runtime/sdl/src/GameWindow.cs
@@ -32,7 +32,11 @@ namespace CivOne
 		private int _settingsWindowWidth = Settings.WindowWidth;
 		private int _settingsWindowHeight = Settings.WindowHeight;
 		private Point _settingsWindowPosition = Settings.WindowPosition;
+		private Point _pendingWindowPosition = Settings.WindowPosition;
+		private bool _hasPendingWindowPositionPersist;
+		private DateTime _lastWindowPositionChangeUtc = DateTime.MinValue;
 		private bool _settingsWindowMaximized = Settings.WindowMaximized;
+		private static readonly TimeSpan WindowPositionPersistDebounce = TimeSpan.FromSeconds(1);
 
 		private void Load(object sender, EventArgs args)
 		{
@@ -51,7 +55,11 @@ namespace CivOne
 			SyncWindowedStateWithSettings();
 			
 			Runtime.CanvasSize = SetCanvasSize();
-			if (_runtime.SignalQuit) StopRunning();
+			if (_runtime.SignalQuit)
+			{
+				PersistPendingWindowPositionIfNeeded();
+				StopRunning();
+			}
 		}
 
 		private void ApplyFullscreenSettingChanges()
@@ -186,8 +194,31 @@ namespace CivOne
 				return;
 			}
 
-			_settingsWindowPosition = currentPosition;
-			Settings.WindowPosition = currentPosition;
+			if (!_hasPendingWindowPositionPersist || currentPosition != _pendingWindowPosition)
+			{
+				_pendingWindowPosition = currentPosition;
+				_lastWindowPositionChangeUtc = DateTime.UtcNow;
+				_hasPendingWindowPositionPersist = true;
+			}
+
+			if ((DateTime.UtcNow - _lastWindowPositionChangeUtc) < WindowPositionPersistDebounce)
+			{
+				return;
+			}
+
+			PersistPendingWindowPositionIfNeeded();
+		}
+
+		private void PersistPendingWindowPositionIfNeeded()
+		{
+			if (!_hasPendingWindowPositionPersist)
+			{
+				return;
+			}
+
+			_settingsWindowPosition = _pendingWindowPosition;
+			Settings.WindowPosition = _pendingWindowPosition;
+			_hasPendingWindowPositionPersist = false;
 		}
 
 		private void Draw(object sender, EventArgs args)

--- a/runtime/sdl/src/GameWindow.cs
+++ b/runtime/sdl/src/GameWindow.cs
@@ -20,6 +20,7 @@ namespace CivOne
 	internal partial class GameWindow : SDL.Window
 	{
 		private readonly Runtime _runtime;
+		private readonly IDebounceService _debounceService;
 
 		private static Settings Settings => Settings.Instance;
 
@@ -31,12 +32,11 @@ namespace CivOne
 		private int _settingsScale = Settings.Scale;
 		private int _settingsWindowWidth = Settings.WindowWidth;
 		private int _settingsWindowHeight = Settings.WindowHeight;
+		private Size? _pendingWindowSizeCandidate;
 		private Point _settingsWindowPosition = Settings.WindowPosition;
-		private Point _pendingWindowPosition = Settings.WindowPosition;
-		private bool _hasPendingWindowPositionPersist;
-		private DateTime _lastWindowPositionChangeUtc = DateTime.MinValue;
+		private Point? _pendingWindowPositionCandidate;
 		private bool _settingsWindowMaximized = Settings.WindowMaximized;
-		private static readonly TimeSpan WindowPositionPersistDebounce = TimeSpan.FromSeconds(1);
+		private static readonly TimeSpan WindowPersistDebounce = TimeSpan.FromSeconds(1);
 
 		private void Load(object sender, EventArgs args)
 		{
@@ -53,11 +53,12 @@ namespace CivOne
 			ApplyFullscreenSettingChanges();
 			ApplyScaleSettingChanges();
 			SyncWindowedStateWithSettings();
+			_debounceService.ExecuteDueCallbacks();
 			
 			Runtime.CanvasSize = SetCanvasSize();
 			if (_runtime.SignalQuit)
 			{
-				PersistPendingWindowPositionIfNeeded();
+				_debounceService.FlushPendingCallbacks();
 				StopRunning();
 			}
 		}
@@ -88,6 +89,7 @@ namespace CivOne
 
 			_settingsWindowWidth = displaySize.Width;
 			_settingsWindowHeight = displaySize.Height;
+			_pendingWindowSizeCandidate = null;
 			Settings.WindowWidth = displaySize.Width;
 			Settings.WindowHeight = displaySize.Height;
 		}
@@ -171,19 +173,44 @@ namespace CivOne
 			SetWindowSize(configuredWidth, configuredHeight);
 			_settingsWindowWidth = configuredWidth;
 			_settingsWindowHeight = configuredHeight;
+			_pendingWindowSizeCandidate = null;
+			_debounceService.Cancel(GameDebounceKeys.WindowSize);
 		}
 
 		private void PersistCurrentWindowSize(int currentWidth, int currentHeight)
 		{
 			if (currentWidth == _settingsWindowWidth && currentHeight == _settingsWindowHeight)
 			{
+				_pendingWindowSizeCandidate = null;
 				return;
 			}
 
-			_settingsWindowWidth = currentWidth;
-			_settingsWindowHeight = currentHeight;
-			Settings.WindowWidth = currentWidth;
-			Settings.WindowHeight = currentHeight;
+			Size currentSize = new Size(currentWidth, currentHeight);
+			if (_pendingWindowSizeCandidate.HasValue && _pendingWindowSizeCandidate.Value == currentSize)
+			{
+				return;
+			}
+
+			_pendingWindowSizeCandidate = currentSize;
+			_debounceService.Debounce(GameDebounceKeys.WindowSize, WindowPersistDebounce, () => PersistWindowSize(currentSize));
+		}
+
+		private void PersistWindowSize(Size size)
+		{
+			if (size.Width == _settingsWindowWidth && size.Height == _settingsWindowHeight)
+			{
+				return;
+			}
+
+			_settingsWindowWidth = size.Width;
+			_settingsWindowHeight = size.Height;
+			_pendingWindowSizeCandidate = null;
+			Settings.WindowWidth = size.Width;
+			Settings.WindowHeight = size.Height;
+
+#if DEBUG
+			_runtime.Log($"[Debounce] Persisted window size: {size.Width}x{size.Height}");
+#endif
 		}
 
 		private void PersistWindowPosition()
@@ -191,34 +218,33 @@ namespace CivOne
 			Point currentPosition = new Point(PositionX, PositionY);
 			if (currentPosition == _settingsWindowPosition)
 			{
+				_pendingWindowPositionCandidate = null;
 				return;
 			}
 
-			if (!_hasPendingWindowPositionPersist || currentPosition != _pendingWindowPosition)
-			{
-				_pendingWindowPosition = currentPosition;
-				_lastWindowPositionChangeUtc = DateTime.UtcNow;
-				_hasPendingWindowPositionPersist = true;
-			}
-
-			if ((DateTime.UtcNow - _lastWindowPositionChangeUtc) < WindowPositionPersistDebounce)
+			if (_pendingWindowPositionCandidate.HasValue && _pendingWindowPositionCandidate.Value == currentPosition)
 			{
 				return;
 			}
 
-			PersistPendingWindowPositionIfNeeded();
+			_pendingWindowPositionCandidate = currentPosition;
+			_debounceService.Debounce(GameDebounceKeys.WindowPosition, WindowPersistDebounce, () => PersistWindowPositionValue(currentPosition));
 		}
 
-		private void PersistPendingWindowPositionIfNeeded()
+		private void PersistWindowPositionValue(Point position)
 		{
-			if (!_hasPendingWindowPositionPersist)
+			if (position == _settingsWindowPosition)
 			{
 				return;
 			}
 
-			_settingsWindowPosition = _pendingWindowPosition;
-			Settings.WindowPosition = _pendingWindowPosition;
-			_hasPendingWindowPositionPersist = false;
+			_settingsWindowPosition = position;
+			_pendingWindowPositionCandidate = null;
+			Settings.WindowPosition = position;
+
+#if DEBUG
+			_runtime.Log($"[Debounce] Persisted window position: X={position.X}, Y={position.Y}");
+#endif
 		}
 
 		private void Draw(object sender, EventArgs args)
@@ -367,18 +393,21 @@ namespace CivOne
 
 			SetWindowPosition(x, y);
 			_settingsWindowPosition = new Point(x, y);
+			_pendingWindowPositionCandidate = null;
 			Settings.WindowPosition = _settingsWindowPosition;
 
 			Maximized = Settings.WindowMaximized;
 			_settingsWindowMaximized = Settings.WindowMaximized;
 		}
 
-		public GameWindow(Runtime runtime, bool softwareRender) : base("CivOne", InitialWidth, InitialHeight, Settings.FullScreen, softwareRender)
+		public GameWindow(Runtime runtime, bool softwareRender, IDebounceService debounceService) : base("CivOne", InitialWidth, InitialHeight, Settings.FullScreen, softwareRender)
 		{
+			_runtime = runtime;
+			_debounceService = debounceService ?? throw new ArgumentNullException(nameof(debounceService));
+
 			Icon = Resources.GetWindowIcon();
 			RestoreWindowPlacement();
 
-			_runtime = runtime;
 			_runtime.CursorChanged += CursorChanged;
 			_runtime.SetWindowTitle += (string title) => Title = title;
 

--- a/runtime/sdl/src/GameWindow.cs
+++ b/runtime/sdl/src/GameWindow.cs
@@ -31,6 +31,8 @@ namespace CivOne
 		private int _settingsScale = Settings.Scale;
 		private int _settingsWindowWidth = Settings.WindowWidth;
 		private int _settingsWindowHeight = Settings.WindowHeight;
+		private Point _settingsWindowPosition = Settings.WindowPosition;
+		private bool _settingsWindowMaximized = Settings.WindowMaximized;
 
 		private void Load(object sender, EventArgs args)
 		{
@@ -44,56 +46,148 @@ namespace CivOne
 			_runtime.InvokeUpdate(ref updateArgs);
 			_hasUpdate = (_hasUpdate || updateArgs.HasUpdate);
 
-			if (_settingsFullscreen != Settings.FullScreen)
-			{
-				_settingsFullscreen = Settings.FullScreen;
-				if (_settingsFullscreen)
-				{
-					// Save the display resolution so WindowSize knows the screen dimensions
-					var displaySize = GetDisplaySize();
-					if (displaySize.Width > 0 && displaySize.Height > 0)
-					{
-						_settingsWindowWidth  = displaySize.Width;
-						_settingsWindowHeight = displaySize.Height;
-						Settings.WindowWidth  = displaySize.Width;
-						Settings.WindowHeight = displaySize.Height;
-					}
-				}
-				Fullscreen = _settingsFullscreen;
-			}
-
-			if (_settingsScale != Settings.Scale)
-			{
-				ResetWindowScale();
-				_settingsScale = Settings.Scale;
-			}
-
-			if (!Settings.FullScreen)
-			{
-				int settW = Settings.WindowWidth;
-				int settH = Settings.WindowHeight;
-				int winW = Width;
-				int winH = Height;
-
-				// Settings changed externally (e.g. preset selected in Setup menu) → resize window immediately
-				if (settW > 0 && settH > 0 && (settW != _settingsWindowWidth || settH != _settingsWindowHeight) && (settW != winW || settH != winH))
-				{
-					SetWindowSize(settW, settH);
-					_settingsWindowWidth = settW;
-					_settingsWindowHeight = settH;
-				}
-				// Window was resized by user → persist to settings
-				else if (winW != _settingsWindowWidth || winH != _settingsWindowHeight)
-				{
-					_settingsWindowWidth = winW;
-					_settingsWindowHeight = winH;
-					Settings.WindowWidth = winW;
-					Settings.WindowHeight = winH;
-				}
-			}
+			ApplyFullscreenSettingChanges();
+			ApplyScaleSettingChanges();
+			SyncWindowedStateWithSettings();
 			
 			Runtime.CanvasSize = SetCanvasSize();
 			if (_runtime.SignalQuit) StopRunning();
+		}
+
+		private void ApplyFullscreenSettingChanges()
+		{
+			if (_settingsFullscreen == Settings.FullScreen)
+			{
+				return;
+			}
+
+			_settingsFullscreen = Settings.FullScreen;
+			if (_settingsFullscreen)
+			{
+				PersistDisplayResolutionAsWindowSize();
+			}
+
+			Fullscreen = _settingsFullscreen;
+		}
+
+		private void PersistDisplayResolutionAsWindowSize()
+		{
+			Size displaySize = GetDisplaySize();
+			if (displaySize.Width <= 0 || displaySize.Height <= 0)
+			{
+				return;
+			}
+
+			_settingsWindowWidth = displaySize.Width;
+			_settingsWindowHeight = displaySize.Height;
+			Settings.WindowWidth = displaySize.Width;
+			Settings.WindowHeight = displaySize.Height;
+		}
+
+		private void ApplyScaleSettingChanges()
+		{
+			if (_settingsScale == Settings.Scale)
+			{
+				return;
+			}
+
+			ResetWindowScale();
+			_settingsScale = Settings.Scale;
+		}
+
+		private void SyncWindowedStateWithSettings()
+		{
+			if (Settings.FullScreen)
+			{
+				return;
+			}
+
+			SyncMaximizedState();
+			if (_settingsWindowMaximized)
+			{
+				return;
+			}
+
+			SyncWindowSize();
+			PersistWindowPosition();
+		}
+
+		private void SyncMaximizedState()
+		{
+			if (_settingsWindowMaximized != Settings.WindowMaximized)
+			{
+				_settingsWindowMaximized = Settings.WindowMaximized;
+				Maximized = _settingsWindowMaximized;
+			}
+
+			bool isWindowMaximized = Maximized;
+			if (isWindowMaximized == _settingsWindowMaximized)
+			{
+				return;
+			}
+
+			_settingsWindowMaximized = isWindowMaximized;
+			Settings.WindowMaximized = isWindowMaximized;
+		}
+
+		private void SyncWindowSize()
+		{
+			int configuredWidth = Settings.WindowWidth;
+			int configuredHeight = Settings.WindowHeight;
+			int currentWidth = Width;
+			int currentHeight = Height;
+
+			if (ShouldApplyConfiguredWindowSize(configuredWidth, configuredHeight, currentWidth, currentHeight))
+			{
+				ApplyConfiguredWindowSize(configuredWidth, configuredHeight);
+				return;
+			}
+
+			PersistCurrentWindowSize(currentWidth, currentHeight);
+		}
+
+		private bool ShouldApplyConfiguredWindowSize(int configuredWidth, int configuredHeight, int currentWidth, int currentHeight)
+		{
+			if (configuredWidth <= 0 || configuredHeight <= 0)
+			{
+				return false;
+			}
+
+			bool configuredSizeChanged = configuredWidth != _settingsWindowWidth || configuredHeight != _settingsWindowHeight;
+			bool windowAlreadyHasConfiguredSize = configuredWidth == currentWidth && configuredHeight == currentHeight;
+			return configuredSizeChanged && !windowAlreadyHasConfiguredSize;
+		}
+
+		private void ApplyConfiguredWindowSize(int configuredWidth, int configuredHeight)
+		{
+			SetWindowSize(configuredWidth, configuredHeight);
+			_settingsWindowWidth = configuredWidth;
+			_settingsWindowHeight = configuredHeight;
+		}
+
+		private void PersistCurrentWindowSize(int currentWidth, int currentHeight)
+		{
+			if (currentWidth == _settingsWindowWidth && currentHeight == _settingsWindowHeight)
+			{
+				return;
+			}
+
+			_settingsWindowWidth = currentWidth;
+			_settingsWindowHeight = currentHeight;
+			Settings.WindowWidth = currentWidth;
+			Settings.WindowHeight = currentHeight;
+		}
+
+		private void PersistWindowPosition()
+		{
+			Point currentPosition = new Point(PositionX, PositionY);
+			if (currentPosition == _settingsWindowPosition)
+			{
+				return;
+			}
+
+			_settingsWindowPosition = currentPosition;
+			Settings.WindowPosition = currentPosition;
 		}
 
 		private void Draw(object sender, EventArgs args)
@@ -224,9 +318,34 @@ namespace CivOne
 			_runtime.InvokeMouseUp(args);
 		}
 
+		private void RestoreWindowPlacement()
+		{
+			if (Settings.FullScreen)
+			{
+				return;
+			}
+
+			Point position = Settings.WindowPosition;
+			int x = position.X;
+			int y = position.Y;
+			if (x < 0 || y < 0 || !IsPointInAnyDisplay(x, y))
+			{
+				x = 0;
+				y = 0;
+			}
+
+			SetWindowPosition(x, y);
+			_settingsWindowPosition = new Point(x, y);
+			Settings.WindowPosition = _settingsWindowPosition;
+
+			Maximized = Settings.WindowMaximized;
+			_settingsWindowMaximized = Settings.WindowMaximized;
+		}
+
 		public GameWindow(Runtime runtime, bool softwareRender) : base("CivOne", InitialWidth, InitialHeight, Settings.FullScreen, softwareRender)
 		{
 			Icon = Resources.GetWindowIcon();
+			RestoreWindowPlacement();
 
 			_runtime = runtime;
 			_runtime.CursorChanged += CursorChanged;

--- a/runtime/sdl/src/Program.cs
+++ b/runtime/sdl/src/Program.cs
@@ -158,13 +158,14 @@ Try 'civone-sdl --help' for more information.
 				settings["no-sound"] = true;
 			}
 
-			using (Runtime runtime = new Runtime(settings))
-			using (GameWindow window = new GameWindow(runtime, (bool)settings["software-render"]))
-			{
-				runtime.Log("Game started");
-				window.Run();
-				runtime.Log("Game stopped");
-			}
+			using Runtime runtime = new(settings);
+			IUtcClock clock = new SystemUtcClock();
+			IDebounceService debounceService = DebounceServiceFactory.Create(message => runtime.Log(message), clock);
+			
+			using GameWindow window = new(runtime, (bool)settings["software-render"], debounceService);
+			runtime.Log("Game started");
+			window.Run();
+			runtime.Log("Game stopped");
 		}
 	}
 }

--- a/runtime/sdl/src/Program.cs
+++ b/runtime/sdl/src/Program.cs
@@ -8,6 +8,8 @@
 // work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using CivOne.Enums;
 
@@ -15,12 +17,51 @@ namespace CivOne
 {
 	internal class Program
 	{
+		private static readonly string[] MacSdlLibraryCandidates =
+		[
+			"/Library/Frameworks/SDL2.framework/Versions/Current/SDL2",
+			"/opt/homebrew/lib/libSDL2.dylib",
+			"/opt/homebrew/lib/libSDL2-2.0.0.dylib",
+			"/usr/local/lib/libSDL2.dylib",
+			"/usr/local/lib/libSDL2-2.0.0.dylib"
+		];
+
 		private static string ErrorText => @"civone-sdl: Invalid options: '{0}'
 Try 'civone-sdl --help' for more information.
 ";
 
+		private static void RegisterNativeResolver()
+		{
+			if (Native.Platform != Platform.macOS)
+			{
+				return;
+			}
+
+			NativeLibrary.SetDllImportResolver(typeof(SDL).Assembly, ResolveSdlLibrary);
+		}
+
+		private static IntPtr ResolveSdlLibrary(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+		{
+			if (!libraryName.Contains("SDL2", StringComparison.OrdinalIgnoreCase))
+			{
+				return IntPtr.Zero;
+			}
+
+			foreach (string libraryPath in MacSdlLibraryCandidates)
+			{
+				if (NativeLibrary.TryLoad(libraryPath, out IntPtr handle))
+				{
+					return handle;
+				}
+			}
+
+			return IntPtr.Zero;
+		}
+
 		private static void Main(string[] args)
 		{
+			RegisterNativeResolver();
+
 			RuntimeSettings settings = new RuntimeSettings();
 			settings["software-render"] = false;
 			settings["no-sound"] = false;

--- a/runtime/sdl/src/SDL/Extern.cs
+++ b/runtime/sdl/src/SDL/Extern.cs
@@ -44,6 +44,15 @@ namespace CivOne
 		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
 		private static extern void SDL_GetWindowSize(IntPtr window, out int width, out int height);
 
+		[DllImport(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
+		private static extern int SDL_GetWindowDisplayIndex(IntPtr window);
+
+		[StructLayout(LayoutKind.Sequential)]
+		private struct SDL_DisplayRect { public int x, y, w, h; }
+
+		[DllImport(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
+		private static extern int SDL_GetDisplayBounds(int displayIndex, out SDL_DisplayRect rect);
+
 		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
 		private static extern void SDL_SetWindowSize(IntPtr window, int width, int height);
 

--- a/runtime/sdl/src/SDL/Extern.cs
+++ b/runtime/sdl/src/SDL/Extern.cs
@@ -44,6 +44,9 @@ namespace CivOne
 		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
 		private static extern void SDL_GetWindowSize(IntPtr window, out int width, out int height);
 
+		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
+		private static extern void SDL_GetWindowPosition(IntPtr window, out int x, out int y);
+
 		[DllImport(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
 		private static extern int SDL_GetWindowDisplayIndex(IntPtr window);
 
@@ -53,11 +56,26 @@ namespace CivOne
 		[DllImport(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
 		private static extern int SDL_GetDisplayBounds(int displayIndex, out SDL_DisplayRect rect);
 
+		[DllImport(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
+		private static extern int SDL_GetNumVideoDisplays();
+
 		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
 		private static extern void SDL_SetWindowSize(IntPtr window, int width, int height);
 
 		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
+		private static extern void SDL_SetWindowPosition(IntPtr window, int x, int y);
+
+		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
 		private static extern void SDL_SetWindowFullscreen(IntPtr window, SDL_WINDOW flags);
+
+		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
+		private static extern uint SDL_GetWindowFlags(IntPtr window);
+
+		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
+		private static extern void SDL_MaximizeWindow(IntPtr window);
+
+		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
+		private static extern void SDL_RestoreWindow(IntPtr window);
 
 		[DllImportAttribute(DLL_SDL, CallingConvention = CallingConvention.Cdecl)]
 		private static extern void SDL_Delay(uint ms);

--- a/runtime/sdl/src/SDL/Window.cs
+++ b/runtime/sdl/src/SDL/Window.cs
@@ -284,6 +284,16 @@ namespace CivOne
 				SDL_SetWindowSize(_handle, width, height);
 			}
 
+			/// <summary>Returns the resolution of the display the window is currently on.</summary>
+			protected Size GetDisplaySize()
+			{
+				int idx = SDL_GetWindowDisplayIndex(_handle);
+				if (idx < 0) return Size.Empty;
+				if (SDL_GetDisplayBounds(idx, out SDL_DisplayRect r) != 0) 
+					return Size.Empty;
+				return new Size(r.w, r.h);
+			}
+
 			public void Dispose()
 			{
 				SDL_DestroyRenderer(_renderer);

--- a/runtime/sdl/src/SDL/Window.cs
+++ b/runtime/sdl/src/SDL/Window.cs
@@ -199,6 +199,36 @@ namespace CivOne
 				}
 			}
 
+			protected int PositionX
+			{
+				get
+				{
+					SDL_GetWindowPosition(_handle, out int x, out _);
+					return x;
+				}
+			}
+
+			protected int PositionY
+			{
+				get
+				{
+					SDL_GetWindowPosition(_handle, out _, out int y);
+					return y;
+				}
+			}
+
+			protected bool Maximized
+			{
+				get => (SDL_GetWindowFlags(_handle) & (uint)SDL_WINDOW.MAXIMIZED) != 0;
+				set
+				{
+					if (value)
+						SDL_MaximizeWindow(_handle);
+					else
+						SDL_RestoreWindow(_handle);
+				}
+			}
+
 			private string _title;
 			public string Title
 			{
@@ -284,6 +314,11 @@ namespace CivOne
 				SDL_SetWindowSize(_handle, width, height);
 			}
 
+			protected void SetWindowPosition(int x, int y)
+			{
+				SDL_SetWindowPosition(_handle, x, y);
+			}
+
 			/// <summary>Returns the resolution of the display the window is currently on.</summary>
 			protected Size GetDisplaySize()
 			{
@@ -292,6 +327,30 @@ namespace CivOne
 				if (SDL_GetDisplayBounds(idx, out SDL_DisplayRect r) != 0) 
 					return Size.Empty;
 				return new Size(r.w, r.h);
+			}
+
+			protected bool IsPointInAnyDisplay(int x, int y)
+			{
+				int displays = SDL_GetNumVideoDisplays();
+				if (displays <= 0)
+				{
+					return true;
+				}
+
+				for (int i = 0; i < displays; i++)
+				{
+					if (SDL_GetDisplayBounds(i, out SDL_DisplayRect r) != 0)
+					{
+						continue;
+					}
+
+					if (x >= r.x && x < (r.x + r.w) && y >= r.y && y < (r.y + r.h))
+					{
+						return true;
+					}
+				}
+
+				return false;
 			}
 
 			public void Dispose()

--- a/runtime/sdl/src/Services/DebounceKeys.cs
+++ b/runtime/sdl/src/Services/DebounceKeys.cs
@@ -1,0 +1,17 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+namespace CivOne
+{
+	public static class GameDebounceKeys
+	{
+		public const string WindowSize = "window-size";
+		public const string WindowPosition = "window-position";
+	}
+}

--- a/runtime/sdl/src/Services/DebounceService.cs
+++ b/runtime/sdl/src/Services/DebounceService.cs
@@ -1,0 +1,128 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CivOne
+{
+	/// <summary>
+	/// Default implementation of <see cref="IDebounceService"/>.
+	/// Stores one pending callback per key and executes callbacks on explicit polling.
+	/// </summary>
+	/// <remarks>
+	/// Design notes:
+	/// - Keyed debounce: the latest callback replaces previous callbacks for the same key.
+	/// - No background timer/thread is used; caller controls execution by calling
+	///   <see cref="ExecuteDueCallbacks"/> in the update loop.
+	/// - <see cref="FlushPendingCallbacks"/> is intended for shutdown to avoid losing
+	///   the last buffered write.
+	/// </remarks>
+	/// <remarks>
+	/// Creates a debounce service with an injectable UTC clock.
+	/// </remarks>
+	/// <param name="clock">UTC time source used for due-time calculations.</param>
+	/// <param name="log">Optional error logger for callback exceptions.</param>
+	public sealed class DebounceService(IUtcClock clock, Action<string> log) : IDebounceService
+	{
+		private sealed class PendingCallback(DateTime dueAtUtc, Action callback)
+		{
+			public DateTime DueAtUtc { get; set; } = dueAtUtc;
+			public Action Callback { get; set; } = callback;
+		}
+
+		private readonly IUtcClock _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+		private readonly Action<string> _log = log;
+		private readonly Dictionary<string, PendingCallback> _pending = [];
+		private readonly object _sync = new object();
+
+		public void Debounce(string key, TimeSpan delay, Action callback)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+			{
+				throw new ArgumentException("Debounce key must be non-empty.", nameof(key));
+			}
+
+			ArgumentNullException.ThrowIfNull(callback);
+
+			if (delay < TimeSpan.Zero)
+			{
+				delay = TimeSpan.Zero;
+			}
+
+			DateTime dueAt = _clock.UtcNow.Add(delay);
+			lock (_sync)
+			{
+				_pending[key] = new PendingCallback(dueAt, callback);
+			}
+		}
+
+		public void Cancel(string key)
+		{
+			if (string.IsNullOrWhiteSpace(key))
+			{
+				return;
+			}
+
+			lock (_sync)
+			{
+				_pending.Remove(key);
+			}
+		}
+
+		public void ExecuteDueCallbacks()
+		{
+			DateTime now = _clock.UtcNow;
+			List<KeyValuePair<string, PendingCallback>> dueEntries;
+
+			lock (_sync)
+			{
+				dueEntries = _pending.Where(entry => entry.Value.DueAtUtc <= now).ToList();
+				foreach (var entry in dueEntries)
+				{
+					_pending.Remove(entry.Key);
+				}
+			}
+
+			foreach (var entry in dueEntries)
+			{
+				Execute(entry.Key, entry.Value.Callback);
+			}
+		}
+
+		public void FlushPendingCallbacks()
+		{
+			List<KeyValuePair<string, PendingCallback>> allEntries;
+
+			lock (_sync)
+			{
+				allEntries = _pending.ToList();
+				_pending.Clear();
+			}
+
+			foreach (var entry in allEntries)
+			{
+				Execute(entry.Key, entry.Value.Callback);
+			}
+		}
+
+		private void Execute(string key, Action callback)
+		{
+			try
+			{
+				callback();
+			}
+			catch (Exception ex)
+			{
+				_log?.Invoke($"Debounce callback for key '{key}' failed: {ex}");
+			}
+		}
+	}
+}

--- a/runtime/sdl/src/Services/DebounceServiceFactory.cs
+++ b/runtime/sdl/src/Services/DebounceServiceFactory.cs
@@ -1,0 +1,28 @@
+#nullable enable
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+using System;
+
+namespace CivOne
+{
+	/// <summary>
+	/// Creates <see cref="IDebounceService"/> instances.
+	/// Centralizes debounce implementation selection so future variants
+	/// (e.g. timer-based or multithreaded) can be swapped without touching callers.
+	/// Current implementation is a simple single-threaded service that relies on regular calls to ExecuteDueCallbacks() from the main loop.
+	/// If no clock is provided, uses SystemUtcClock which simply returns DateTime.UtcNow. 
+	/// This indirection allows tests to use a mock clock for deterministic timing.
+	/// </summary>
+	public static class DebounceServiceFactory
+	{
+		public static IDebounceService Create(Action<string> log, IUtcClock? clock = null)
+			=> new DebounceService(clock ?? new SystemUtcClock(), log);
+	}
+}

--- a/runtime/sdl/src/Services/IDebounceService.cs
+++ b/runtime/sdl/src/Services/IDebounceService.cs
@@ -1,0 +1,57 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+using System;
+
+namespace CivOne
+{
+	/// <summary>
+	/// Schedules callbacks so that only the latest callback per key executes after a quiet period.
+	/// </summary>
+	/// <remarks>
+	/// Typical usage in a frame/update loop:
+	/// <code>
+	/// _debounceService.Debounce("window-size", TimeSpan.FromSeconds(1), () =&gt;
+	/// {
+	///     Settings.WindowWidth = width;
+	///     Settings.WindowHeight = height;
+	/// });
+	///
+	/// // Called each update tick:
+	/// _debounceService.ExecuteDueCallbacks();
+	///
+	/// // Called on quit:
+	/// _debounceService.FlushPendingCallbacks();
+	/// </code>
+	/// </remarks>
+	public interface IDebounceService
+	{
+		/// <summary>
+		/// Schedules or replaces the callback for <paramref name="key"/>.
+		/// Only the latest callback for that key is kept.
+		/// </summary>
+		void Debounce(string key, TimeSpan delay, Action callback);
+
+		/// <summary>
+		/// Removes a pending callback for <paramref name="key"/>, if any.
+		/// </summary>
+		void Cancel(string key);
+
+		/// <summary>
+		/// Executes callbacks whose debounce delay has elapsed.
+		/// </summary>
+		void ExecuteDueCallbacks();
+
+		/// <summary>
+		/// Executes all pending callbacks immediately.
+		/// Intended for controlled shutdown.
+		/// </summary>
+		void FlushPendingCallbacks();
+	}
+}

--- a/runtime/sdl/src/Services/IUtcClock.cs
+++ b/runtime/sdl/src/Services/IUtcClock.cs
@@ -1,0 +1,18 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+using System;
+
+namespace CivOne
+{
+	public interface IUtcClock
+	{
+		DateTime UtcNow { get; }
+	}
+}

--- a/runtime/sdl/src/Services/SystemUtcClock.cs
+++ b/runtime/sdl/src/Services/SystemUtcClock.cs
@@ -1,0 +1,18 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+using System;
+
+namespace CivOne
+{
+	public sealed class SystemUtcClock : IUtcClock
+	{
+		public DateTime UtcNow => DateTime.UtcNow;
+	}
+}

--- a/src/AI.cs
+++ b/src/AI.cs
@@ -15,6 +15,7 @@ using CivOne.Buildings;
 using CivOne.Enums;
 using CivOne.Governments;
 using CivOne.Leaders;
+using CivOne.Services.Pathfinding;
 using CivOne.Tasks;
 using CivOne.Tiles;
 using CivOne.Units;
@@ -29,6 +30,7 @@ namespace CivOne
 	{
 		public Player Player { get; }
 		public ILeader Leader => Player.Civilization.Leader;
+		private readonly IAiGotoExecutorFactory _gotoExecutorFactory;
 
 		internal void Move(IUnit unit)
 		{
@@ -134,6 +136,19 @@ namespace CivOne
 
 					if (!unit.Goto.IsEmpty)
 					{
+						IAiGotoExecutor gotoExecutor = _gotoExecutorFactory.CreateFor(unit);
+						AiGotoExecutionResult gotoExecutionResult = gotoExecutor.TryExecute(unit);
+
+						if (gotoExecutionResult == AiGotoExecutionResult.Continue)
+						{
+							continue;
+						}
+
+						if (gotoExecutionResult == AiGotoExecutionResult.TurnComplete)
+						{
+							return;
+						}
+
 						int distance = unit.Tile.DistanceTo(unit.Goto);
 						ITile[] tiles = unit.MoveTargets.OrderBy(x => x.DistanceTo(unit.Goto)).ThenBy(x => x.Movement).ToArray();
 						if (tiles.Length == 0 || tiles[0].DistanceTo(unit.Goto) > distance)
@@ -302,13 +317,18 @@ namespace CivOne
 		{
 			if (_instances.ContainsKey(player))
 				return _instances[player];
-			_instances.Add(player, new AI(player));
+			_instances.Add(player, Create(player));
 			return _instances[player];
 		}
 
-		private AI(Player player)
+		private AI(Player player, IAiGotoExecutorFactory gotoExecutorFactory)
 		{
 			Player = player;
+			_gotoExecutorFactory = gotoExecutorFactory;
 		}
+
+		private static IAiGotoExecutorFactory CreateGotoExecutorFactory() => IAiGotoExecutorFactory.Create();
+
+		internal static AI Create(Player player) => new(player, CreateGotoExecutorFactory());
 	}
 }

--- a/src/City.cs
+++ b/src/City.cs
@@ -1572,6 +1572,28 @@ namespace CivOne
 			SetTradingCityIds([.. (_tradingCityIds ?? []), city.Id]);
 		}
 
+		internal void RemoveTradingCity(City city)
+		{
+			if (city == null || _tradingCityIds == null || _tradingCityIds.Length == 0)
+			{
+				return;
+			}
+
+			SetTradingCityIds([.. _tradingCityIds.Where(id => id != city.Id)]);
+		}
+
+		internal void RemoveTradingCitiesOwnedBy(byte owner)
+		{
+			if (_tradingCityIds == null || _tradingCityIds.Length == 0)
+			{
+				return;
+			}
+
+			SetTradingCityIds([.. TradingCitiesAsCity
+				.Where(tradingCity => tradingCity.Owner != owner)
+				.Select(tradingCity => tradingCity.Id)]);
+		}
+
 
 		internal City(byte owner)
 		{

--- a/src/ContinentTraversalDelegate.cs
+++ b/src/ContinentTraversalDelegate.cs
@@ -1,0 +1,110 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+using System;
+using System.Collections.Generic;
+
+namespace CivOne
+{
+    internal sealed class ContinentTraversalDelegate
+    {
+        private readonly int _width;
+        private readonly int _height;
+        private readonly int[,] _relativePositions;
+        private readonly Func<int, int, bool> _isOceanAt;
+        private readonly Func<int, int, byte> _getContinentIdAt;
+        private readonly Action<int, int, byte> _setContinentIdAt;
+
+        internal ContinentTraversalDelegate(
+            int width,
+            int height,
+            int[,] relativePositions,
+            Func<int, int, bool> isOceanAt,
+            Func<int, int, byte> getContinentIdAt,
+            Action<int, int, byte> setContinentIdAt)
+        {
+            _width = width;
+            _height = height;
+            _relativePositions = relativePositions;
+            _isOceanAt = isOceanAt;
+            _getContinentIdAt = getContinentIdAt;
+            _setContinentIdAt = setContinentIdAt;
+        }
+
+        internal ulong CountContinent(int x, int y, bool ocean, byte continentId)
+        {
+            if (_height <= 0 || _width <= 0)
+            {
+                return 0;
+            }
+
+            x = WrapX(x);
+            if (y < 0 || y >= _height)
+            {
+                return 0;
+            }
+
+            if (_isOceanAt(x, y) != ocean || _getContinentIdAt(x, y) > 0)
+            {
+                return 0;
+            }
+
+            ulong continentSize = 1;
+            Queue<(int X, int Y)> queue = new Queue<(int X, int Y)>();
+            _setContinentIdAt(x, y, continentId);
+            queue.Enqueue((x, y));
+
+            while (queue.Count > 0)
+            {
+                (int cx, int cy) = queue.Dequeue();
+                for (int i = 0; i < _relativePositions.GetLength(0); i++)
+                {
+                    int nx = WrapX(cx + _relativePositions[i, 0]);
+                    int ny = cy + _relativePositions[i, 1];
+
+                    if (ny < 0 || ny >= _height)
+                    {
+                        continue;
+                    }
+
+                    if (_isOceanAt(nx, ny) != ocean)
+                    {
+                        continue;
+                    }
+
+                    if (_getContinentIdAt(nx, ny) > 0)
+                    {
+                        continue;
+                    }
+
+                    _setContinentIdAt(nx, ny, continentId);
+                    continentSize++;
+                    queue.Enqueue((nx, ny));
+                }
+            }
+
+            return continentSize;
+        }
+
+        private int WrapX(int x)
+        {
+            if (x < 0)
+            {
+                return x + _width;
+            }
+
+            if (x >= _width)
+            {
+                return x - _width;
+            }
+
+            return x;
+        }
+    }
+}

--- a/src/Game.LoadSave.cs
+++ b/src/Game.LoadSave.cs
@@ -18,6 +18,7 @@ using CivOne.Enums;
 using CivOne.Persistence.Factories;
 using CivOne.Persistence.Model;
 using CivOne.Services.GlobalWarming;
+using CivOne.Services.Random;
 using CivOne.Units;
 using CivOne.Wonders;
 
@@ -42,7 +43,7 @@ namespace CivOne
 			}
 
 			// Always use the save game's seed
-			Common.SetRandomSeed(adapter.RandomSeed);
+			RandomServiceFactory.Reset(adapter.RandomSeed);
 
 			Map.Instance.LoadMap(mapFile, adapter.RandomSeed);
 			_instance = new Game(adapter);

--- a/src/Game.LoadYaml.cs
+++ b/src/Game.LoadYaml.cs
@@ -17,6 +17,7 @@ using CivOne.Persistence.Mapper;
 using CivOne.Persistence.Model;
 using CivOne.Persistence.Yaml;
 using CivOne.Services.GlobalWarming;
+using CivOne.Services.Random;
 using CivOne.Units;
 
 namespace CivOne
@@ -137,7 +138,7 @@ namespace CivOne
 				_replayData.AddRange(state.ReplayData);
 			}
 
-			Common.SetRandomSeed(_valueSanitizer.ClampToUInt16(state.RandomSeed, nameof(Game), nameof(state.RandomSeed)));
+			RandomServiceFactory.Reset(_valueSanitizer.ClampToUInt16(state.RandomSeed, nameof(Game), nameof(state.RandomSeed)));
 		}
 
 		private void ApplyGameOptions(IEnumerable<GameOptionEnum> options)

--- a/src/Game.NewGame.cs
+++ b/src/Game.NewGame.cs
@@ -160,12 +160,18 @@ namespace CivOne
 			}
 		}
 
-		public static void CreateGame(int difficulty, int competition, ICivilization tribe, string leaderName = null, string tribeName = null, string tribeNamePlural = null)
+		public static void CreateGame(int difficulty, int competition, ICivilization tribe, string leaderName = null, string tribeName = null, string tribeNamePlural = null, bool replaceExisting = false)
 		{
 			if (_instance != null)
 			{
-				BaseInstance.Log("ERROR: Game instance already exists");
-				return;
+				if (!replaceExisting)
+				{
+					BaseInstance.Log("ERROR: Game instance already exists");
+					return;
+				}
+
+				BaseInstance.Log("Replacing existing game instance with a new game");
+				_instance = null;
 			}
 			_instance = new Game(difficulty, competition, tribe, leaderName, tribeName, tribeNamePlural);
 

--- a/src/Game.NewGame.cs
+++ b/src/Game.NewGame.cs
@@ -16,6 +16,7 @@ using CivOne.Civilizations;
 using CivOne.Enums;
 using CivOne.Services;
 using CivOne.Services.GlobalWarming;
+using CivOne.Services.Random;
 using CivOne.Tiles;
 using CivOne.Units;
 
@@ -196,6 +197,15 @@ namespace CivOne
 
 		private Game(int difficulty, int competition, ICivilization tribe, string leaderName, string playerTribeName, string playerTribeNamePlural) : this(CreateValueSanitizer())
 		{
+			if (RuntimeHandler.Runtime.Settings.InitialSeed != 0)
+			{
+				RandomServiceFactory.Reset(RuntimeHandler.Runtime.Settings.InitialSeed);
+			}
+			else
+			{
+				RandomServiceFactory.Reset();
+			}
+
 			_loadedFromYamlSaveSource = false;
 
 			_instance = this;

--- a/src/Map.Generate.cs
+++ b/src/Map.Generate.cs
@@ -214,7 +214,7 @@ namespace CivOne
                         switch( _tiles[ x, y ].Type )
                         {
                             case Terrain.Swamp: _tiles[ x, y ] = new Forest( x, y, special ); break;
-                            case Terrain.Plains: new Grassland( x, y ); break;
+                            case Terrain.Plains: _tiles[ x, y ] = new Grassland( x, y ); break;
                             case Terrain.Grassland1:
                             case Terrain.Grassland2: _tiles[ x, y ] = new Jungle( x, y, special ); break;
                             case Terrain.Hills: _tiles[ x, y ] = new Forest( x, y, special ); break;
@@ -439,7 +439,7 @@ namespace CivOne
                     }
                 oOcean = true;
             }
-            Log( "Map: ´Total number of tiles = {0}", nTiles );
+            Log( "Map: ï¿½Total number of tiles = {0}", nTiles );
         }
 
         /* ***********************************************************************************************/

--- a/src/Map.Generate.cs
+++ b/src/Map.Generate.cs
@@ -428,7 +428,7 @@ namespace CivOne
                     }
                 oOcean = true;
             }
-            Log( "Map: �Total number of tiles = {0}", nTiles );
+            Log( "Map: Total number of tiles = {0}", nTiles );
         }
 
         /* ***********************************************************************************************/

--- a/src/Map.Generate.cs
+++ b/src/Map.Generate.cs
@@ -357,23 +357,6 @@ namespace CivOne
         private byte ContinentId;
         private ulong ContinetSize;
 
-        private void CountContinent( int x, int y, bool oOcean )
-        {
-            for( int i = 0; i < 4; i++ )
-            {
-                int XX = x + aiRelPos[ i, 0 ];
-                int YY = y + aiRelPos[ i, 1 ];
-                if( XX < 0 || XX >= WIDTH ) continue;
-                if( YY < 0 || YY >= HEIGHT ) continue;
-
-                if( this[ XX, YY ].IsOcean != oOcean ) continue;
-                if( this[ XX, YY ].ContinentId > 0 ) continue;    // Already counted
-                this[ XX, YY ].ContinentId = ContinentId;
-                ContinetSize++;
-                CountContinent( XX, YY, oOcean );
-            }
-        }
-
         /* ***********************************************************************************************************/
 
         private struct Continent
@@ -389,6 +372,14 @@ namespace CivOne
         {
             Log( "Map: Calculate continent/ocean sizes and give continents a number in size order" );
 
+            ContinentTraversalDelegate continentTraversal = new ContinentTraversalDelegate(
+                WIDTH,
+                HEIGHT,
+                aiRelPos,
+                (x, y) => this[ x, y ].IsOcean,
+                (x, y) => this[ x, y ].ContinentId,
+                (x, y, continentId) => this[ x, y ].ContinentId = continentId);
+
             for( int y = 0; y < HEIGHT; y++ )       // todo  remove JR
                 for( int x = 0; x < WIDTH; x++ )
                     this[ x, y ].ContinentId = 0;
@@ -403,10 +394,8 @@ namespace CivOne
                     for( int x = 0; x < WIDTH; x++ )
                         if( this[ x, y ].ContinentId == 0 && ( this[ x, y ].IsOcean == oOcean ))
                         {  // Found a "new" continent/ocean
-                            ContinetSize = 1;
                             ContinentId++;
-                            this[ x, y ].ContinentId = ContinentId;
-                            CountContinent( x, y, oOcean );         // Here is where the counting is done 
+                            ContinetSize = continentTraversal.CountContinent( x, y, oOcean, ContinentId );
                             Continent continent;
                             continent.ContinentId = ContinentId;
                             continent.ContinetSize = ContinetSize;

--- a/src/Player.cs
+++ b/src/Player.cs
@@ -39,6 +39,17 @@ namespace CivOne
 		private readonly bool[,] _visible = new bool[Map.WIDTH, Map.HEIGHT];
 		private readonly List<byte> _advances = new List<byte>();
 		private readonly List<byte> _embassies = new List<byte>();
+		/// <summary>
+		/// Runtime-only bilateral war state used by the new diplomacy API.
+		/// This state is currently not serialized to, loaded from, or reconstructed from
+		/// legacy SVE diplomacy flags.
+		/// </summary>
+		private readonly HashSet<byte> _warWith = new HashSet<byte>();
+		/// <summary>
+		/// Raw legacy diplomacy bitmask storage (8 targets).
+		/// The bit semantics are not fully documented; gameplay war logic does not currently
+		/// read or write these flags directly.
+		/// </summary>
 		private readonly ushort[] _diplomacy = new ushort[8];
 		private readonly ushort[] _unitsLost = new ushort[28];
 		private readonly ushort[] _unitsDestroyedBy = new ushort[8];
@@ -205,6 +216,155 @@ namespace CivOne
 			byte playerNumber = Game.PlayerNumber(player);
 			if (_embassies.Contains(playerNumber)) return;
 			_embassies.Add(playerNumber);
+		}
+
+		/// <summary>
+		/// WARNING! This state is not persisted to, loaded from, or reconstructed from legacy SVE diplomacy flags or YAML data. 
+		/// Sets or clears runtime war state against a player number.
+		/// This updates only <see cref="_warWith"/> and does not write legacy diplomacy flags.
+		/// </summary>
+		/// <param name="playerNumber">Target player number.</param>
+		/// <param name="atWar">True to set war, false to clear war.</param>
+		internal void SetAtWar(byte playerNumber, bool atWar)
+		{
+			if (Game == null)
+			{
+				return;
+			}
+
+			byte ownPlayerNumber = Game.PlayerNumber(this);
+			if (ownPlayerNumber == 0 || playerNumber == 0 || ownPlayerNumber == playerNumber)
+			{
+				return;
+			}
+
+			if (atWar)
+			{
+				_warWith.Add(playerNumber);
+				return;
+			}
+
+			_warWith.Remove(playerNumber);
+		}
+
+		/// <summary>
+		/// WARNING! This state is not persisted to, loaded from, or reconstructed from legacy SVE diplomacy flags or YAML data. 
+		/// Returns whether this player is currently at war with <paramref name="player"/>
+		/// according to runtime state in <see cref="_warWith"/>.
+		/// This does not consult legacy diplomacy flags.
+		/// </summary>
+		/// <param name="player">Potential enemy player.</param>
+		/// <returns>True if runtime war state is set; otherwise false.</returns>
+		public bool IsAtWar(Player player)
+		{
+			if (player == null || Game == null)
+			{
+				return false;
+			}
+
+			byte ownPlayerNumber = Game.PlayerNumber(this);
+			byte enemyPlayerNumber = Game.PlayerNumber(player);
+			if (ownPlayerNumber == 0 || enemyPlayerNumber == 0 || ownPlayerNumber == enemyPlayerNumber)
+			{
+				return false;
+			}
+
+			return _warWith.Contains(enemyPlayerNumber);
+		}
+
+		/// <summary>
+		/// WARNING! This state is not persisted to, loaded from, or reconstructed from legacy SVE diplomacy flags or YAML data. 
+		/// Declares war symmetrically for both players in runtime state.
+		/// Also removes inter-party trading links and shows advisor messages for human-facing cases.
+		/// This method does not update legacy diplomacy bit flags in SVE data.
+		/// </summary>
+		/// <param name="enemy">The enemy player.</param>
+		public void DeclareWar(Player enemy)
+		{
+			ArgumentNullException.ThrowIfNull(enemy);
+
+			if (Game == null)
+			{
+				return;
+			}
+
+			byte ownPlayerNumber = Game.PlayerNumber(this);
+			byte enemyPlayerNumber = Game.PlayerNumber(enemy);
+			if (ownPlayerNumber == 0 || enemyPlayerNumber == 0 || ownPlayerNumber == enemyPlayerNumber)
+			{
+				return;
+			}
+
+			if (IsAtWar(enemy))
+			{
+				return;
+			}
+
+			SetAtWar(enemyPlayerNumber, true);
+			enemy.SetAtWar(ownPlayerNumber, true);
+			PurgeTradingCitiesForWar(enemyPlayerNumber, ownPlayerNumber);
+
+			if (Game.HumanPlayer == this)
+			{
+				GameTask.Enqueue(Message.Advisor(Advisor.Foreign, false, $"You have declared war on {enemy.TribeName}."));
+			}
+			else if (Game.HumanPlayer == enemy)
+			{
+				GameTask.Enqueue(Message.Advisor(Advisor.Foreign, false, $"{TribeName} has declared war on us."));
+			}
+		}
+
+		/// <summary>
+		/// Makes peace symmetrically for both players in runtime state.
+		/// This method does not update legacy diplomacy bit flags in SVE data.
+		/// </summary>
+		/// <param name="enemy">The enemy player.</param>
+		public void MakePeace(Player enemy)
+		{
+			ArgumentNullException.ThrowIfNull(enemy);
+
+			if (Game == null)
+			{
+				return;
+			}
+
+			byte ownPlayerNumber = Game.PlayerNumber(this);
+			byte enemyPlayerNumber = Game.PlayerNumber(enemy);
+			if (ownPlayerNumber == 0 || enemyPlayerNumber == 0 || ownPlayerNumber == enemyPlayerNumber)
+			{
+				return;
+			}
+
+			if (!IsAtWar(enemy))
+			{
+				return;
+			}
+
+			SetAtWar(enemyPlayerNumber, false);
+			enemy.SetAtWar(ownPlayerNumber, false);
+		}
+
+		/// <summary>
+		/// Removes bilateral trading-city links between both war parties.
+		/// Uses current TradingCities model and does not touch legacy _tradeRoutes structures.
+		/// </summary>
+		/// <param name="enemyPlayerNumber">Enemy player number.</param>
+		/// <param name="ownPlayerNumber">Own player number.</param>
+		private void PurgeTradingCitiesForWar(byte enemyPlayerNumber, byte ownPlayerNumber)
+		{
+			foreach (City city in Cities)
+			{
+				city.SetTradingCityIds([.. city.TradingCitiesAsCity
+					.Where(tradingCity => tradingCity.Owner != enemyPlayerNumber)
+					.Select(tradingCity => tradingCity.Id)]);
+			}
+
+			foreach (City city in Game.GetCities().Where(city => city.Owner == enemyPlayerNumber && city.Size > 0))
+			{
+				city.SetTradingCityIds([.. city.TradingCitiesAsCity
+					.Where(tradingCity => tradingCity.Owner != ownPlayerNumber)
+					.Select(tradingCity => tradingCity.Id)]);
+			}
 		}
 
 		public IAdvance CurrentResearch

--- a/src/Player.cs
+++ b/src/Player.cs
@@ -354,16 +354,12 @@ namespace CivOne
 		{
 			foreach (City city in Cities)
 			{
-				city.SetTradingCityIds([.. city.TradingCitiesAsCity
-					.Where(tradingCity => tradingCity.Owner != enemyPlayerNumber)
-					.Select(tradingCity => tradingCity.Id)]);
+				city.RemoveTradingCitiesOwnedBy(enemyPlayerNumber);
 			}
 
 			foreach (City city in Game.GetCities().Where(city => city.Owner == enemyPlayerNumber && city.Size > 0))
 			{
-				city.SetTradingCityIds([.. city.TradingCitiesAsCity
-					.Where(tradingCity => tradingCity.Owner != ownPlayerNumber)
-					.Select(tradingCity => tradingCity.Id)]);
+				city.RemoveTradingCitiesOwnedBy(ownPlayerNumber);
 			}
 		}
 

--- a/src/RuntimeHandler.cs
+++ b/src/RuntimeHandler.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CivOne.Enums;
 using CivOne.Events;
+using CivOne.Services.Random;
 using CivOne.IO;
 using CivOne.Graphics;
 using CivOne.Graphics.ImageFormats;
@@ -144,7 +145,8 @@ namespace CivOne
 				_currentCursor = Common.MouseCursor;
 				_cursorType = Settings.Instance.CursorType;
 				Runtime.CurrentCursor = _currentCursor;
-				if (Cursor.Current?.Bitmap != null)
+
+				if (_cursorType != CursorType.Native && _currentCursor != MouseCursor.None)
 				{
 					Runtime.Cursor = Cursor.Current.ToBitmap();
 				}
@@ -254,9 +256,9 @@ namespace CivOne
 			// fire-eggs 20170711 init the RNG if user specified
 			// Be aware: Game.LoadSave will override this with the seed from the save game
             if (runtime.Settings.InitialSeed != 0)
-				Common.SetRandomSeed(runtime.Settings.InitialSeed);
+				RandomServiceFactory.Reset(runtime.Settings.InitialSeed);
 			else
-				Common.SetRandomSeed(ushort.MaxValue);
+				RandomServiceFactory.Reset();
 
 
             runtime.Initialize += OnInitialize;

--- a/src/RuntimeHandler.cs
+++ b/src/RuntimeHandler.cs
@@ -36,8 +36,8 @@ namespace CivOne
 		private MouseCursor _currentCursor = MouseCursor.None;
 		private CursorType _cursorType = CursorType.Native;
 
-		internal int CanvasWidth => Math.Max(320, Math.Min(512, Runtime.CanvasWidth));
-		internal int CanvasHeight => Math.Max(200, Math.Min(384, Runtime.CanvasHeight));
+		internal int CanvasWidth => Math.Max(Settings.MinWidth, Math.Min(Settings.MaxScreenWidth, Runtime.CanvasWidth));
+		internal int CanvasHeight => Math.Max(Settings.MinHeight, Math.Min(Settings.MaxScreenHeight, Runtime.CanvasHeight));
 
 		private Stopwatch _tickWatch = new Stopwatch();
 

--- a/src/RuntimeHandler.cs
+++ b/src/RuntimeHandler.cs
@@ -146,14 +146,15 @@ namespace CivOne
 				_cursorType = Settings.Instance.CursorType;
 				Runtime.CurrentCursor = _currentCursor;
 
-				if (_cursorType != CursorType.Native && _currentCursor != MouseCursor.None)
+				if (_cursorType != CursorType.Native && _currentCursor != MouseCursor.None && Cursor.Current?.Bitmap != null)
 				{
 					Runtime.Cursor = Cursor.Current.ToBitmap();
 				}
 				else
 				{
+					// Explicitly clear software cursor texture when using native cursor,
+					// when cursor is hidden, or when no bitmap is available.
 					Runtime.Cursor = null;
-					// CW: prevents cursor invisible if Settings.CursorType changed to Native. (e.g. when goto screen is active)
 					Cursor.ClearCache();
 				}
 			}

--- a/src/Screens/BaseScreen.cs
+++ b/src/Screens/BaseScreen.cs
@@ -70,7 +70,8 @@ namespace CivOne.Screens
 			if (CanExpand && SizeChanged)
 			{
 				// Use capped canvas size here to match SizeChanged checks.
-				// Using Runtime.CanvasWidth can trigger perpetual resize/redraw loops in Expand mode.Resize(CanvasWidth, CanvasHeight);
+				// Using Runtime.CanvasWidth can trigger perpetual resize/redraw loops in Expand mode.
+				Resize(CanvasWidth, CanvasHeight);
 				HasUpdate(gameTick);
 				return true;
 			}

--- a/src/Screens/BaseScreen.cs
+++ b/src/Screens/BaseScreen.cs
@@ -69,7 +69,8 @@ namespace CivOne.Screens
 		{
 			if (CanExpand && SizeChanged)
 			{
-				Resize(Runtime.CanvasWidth, Runtime.CanvasHeight);
+				// Use capped canvas size here to match SizeChanged checks.
+				// Using Runtime.CanvasWidth can trigger perpetual resize/redraw loops in Expand mode.Resize(CanvasWidth, CanvasHeight);
 				HasUpdate(gameTick);
 				return true;
 			}

--- a/src/Screens/Credits.cs
+++ b/src/Screens/Credits.cs
@@ -40,6 +40,7 @@ namespace CivOne.Screens
 		
 		private bool _allowEnterSetup = true;
 		private bool _done;
+		private bool _forceRedraw;
 		private bool _showIntroLine;
 		private bool _introSkipped;
 		private int _introLine = -1;
@@ -100,9 +101,9 @@ namespace CivOne.Screens
 				return true;
 			}
 
-			if (_done && (_overlay == null || !_overlay.Update(gameTick))) return false;
+			if (_done && !_forceRedraw && (_overlay == null || !_overlay.Update(gameTick))) return false;
 
-			if ((gameTick % 3) == 0) return false;
+			if (!_forceRedraw && (gameTick % 3) == 0) return false;
 			
 			// Updates
 			if (_introLeft > -320)
@@ -191,6 +192,7 @@ namespace CivOne.Screens
 				
 				CreateMenu();
 			}
+			_forceRedraw = false;
 			return true;
 		}
 		
@@ -390,11 +392,12 @@ namespace CivOne.Screens
 
 		private void Resize(object sender, ResizeEventArgs args)
 		{
-			_done = false;
+			_forceRedraw = true;
 			foreach (Menu menu in Common.Screens.Where(x => x is Menu && (x as Menu).Id == "MainMenu"))
 			{
 				menu.X = ((Width - 120) / 2) + 3;
 				menu.Y = Height - 55;
+				menu.ForceUpdate();
 			}
 		}
 

--- a/src/Screens/GamePlayPanels/GameMap.cs
+++ b/src/Screens/GamePlayPanels/GameMap.cs
@@ -223,9 +223,10 @@ namespace CivOne.Screens.GamePlayPanels
 		internal void CenterOnPoint(int x, int y)
 		{
 			_x = x - (_tilesX / 2);
-			_y = y - 6;
 			while (_x < 0) _x += Map.WIDTH;
 			while (_x >= Map.WIDTH) _x -= Map.WIDTH;
+
+			_y = y - (_tilesY / 2);
 			if (_y < 0) _y = 0;
 			_y = Math.Min(_y, Math.Max(0, Map.HEIGHT - _tilesY));
 			_update = true;

--- a/src/Screens/GamePlayPanels/GameMap.cs
+++ b/src/Screens/GamePlayPanels/GameMap.cs
@@ -68,6 +68,7 @@ namespace CivOne.Screens.GamePlayPanels
 				for (int xx = 0; xx < tiles.GetLength(0); xx++)
 				{
 					ITile tile = tiles[xx, yy];
+					if (tile == null) continue;
 					if (!Settings.RevealWorld && !Human.Visible(tile)) continue;
 					yield return tile;
 				}
@@ -250,7 +251,8 @@ namespace CivOne.Screens.GamePlayPanels
 			{
 				viewRange = 2;
 			}
-			return (!Map.QueryMapPart(_x + viewRange, _y + viewRange, (_tilesX - (viewRange * 2)), (_tilesY - (viewRange * 2))).Any(t => t.X == unit.X + relX && t.Y == unit.Y + relY));
+			return !Map.QueryMapPart(_x + viewRange, _y + viewRange, (_tilesX - (viewRange * 2)), (_tilesY - (viewRange * 2)))
+				.Any(t => t != null && t.X == unit.X + relX && t.Y == unit.Y + relY);
 		}
 
 		public bool MoveTo(int relX, int relY) // public for unit testing
@@ -492,8 +494,14 @@ namespace CivOne.Screens.GamePlayPanels
 			int yy = _y + y;
 			while (xx  < 0) xx += Map.WIDTH;
 			while (xx  >= Map.WIDTH) xx -= Map.WIDTH;
-			
-			City city = Map[_x + x, _y + y].City;
+
+			ITile selectedTile = Map[xx, yy];
+			if (selectedTile == null)
+			{
+				return false;
+			}
+
+			City city = selectedTile.City;
 			
 			if ((args.Buttons & MouseButton.Right) > 0)
 			{
@@ -509,7 +517,7 @@ namespace CivOne.Screens.GamePlayPanels
 					return true;
 				}
 
-				Common.AddScreen(new Civilopedia(Map[_x + x, _y + y]));
+				Common.AddScreen(new Civilopedia(selectedTile));
 				return _update;
 			}
 			if ((args.Buttons & MouseButton.Left) > 0)
@@ -518,7 +526,7 @@ namespace CivOne.Screens.GamePlayPanels
 				{
 					Common.AddScreen(new CityManager(city));
 				}
-				else if (Map[xx, yy].Units.Any(u => Human == u.Owner))
+				else if (selectedTile.Units.Any(u => Human == u.Owner))
 				{
 					GameTask.Enqueue(Show.UnitStack(xx, yy));
 				}

--- a/src/Screens/GamePlayPanels/GameMap.cs
+++ b/src/Screens/GamePlayPanels/GameMap.cs
@@ -226,8 +226,8 @@ namespace CivOne.Screens.GamePlayPanels
 			_y = y - 6;
 			while (_x < 0) _x += Map.WIDTH;
 			while (_x >= Map.WIDTH) _x -= Map.WIDTH;
-			while (_y < 0) _y++;
-			while (_y + _tilesY > Map.HEIGHT) _y--;
+			if (_y < 0) _y = 0;
+			_y = Math.Min(_y, Math.Max(0, Map.HEIGHT - _tilesY));
 			_update = true;
 			_fullRedraw = true;
 		}
@@ -536,8 +536,8 @@ namespace CivOne.Screens.GamePlayPanels
 					_y += y - 6;
 					while (_x < 0) _x += Map.WIDTH;
 					while (_x >= Map.WIDTH) _x -= Map.WIDTH;
-					while (_y < 0) _y++;
-					while (_y + _tilesY > Map.HEIGHT) _y--;
+					if (_y < 0) _y = 0;
+					_y = Math.Min(_y, Math.Max(0, Map.HEIGHT - _tilesY));
 					_update = true;
 					_fullRedraw = true;
 				}
@@ -547,11 +547,13 @@ namespace CivOne.Screens.GamePlayPanels
 
 		protected override void Resize(int width, int height)
 		{
-			_tilesX = (int)Math.Ceiling((double)width / 16);
-			_tilesY = (int)Math.Ceiling((double)height / 16);
+			// Clamp tile counts to map bounds to prevent infinite adjustment loops
+			_tilesX = Math.Min((int)Math.Ceiling((double)width / 16), Map.WIDTH);
+			_tilesY = Math.Min((int)Math.Ceiling((double)height / 16), Map.HEIGHT);
 
 			Bitmap = new Bytemap(width, height);
-			
+
+			if (_y < 0) _y = 0;
 			while (_y + _tilesY > Map.HEIGHT) _y--;
 			_update = true;
 			_fullRedraw = true;

--- a/src/Screens/GamePlayPanels/GameMap.cs
+++ b/src/Screens/GamePlayPanels/GameMap.cs
@@ -221,10 +221,12 @@ namespace CivOne.Screens.GamePlayPanels
 		
 		internal void CenterOnPoint(int x, int y)
 		{
-			_x = x - 7;
+			_x = x - (_tilesX / 2);
 			_y = y - 6;
+			while (_x < 0) _x += Map.WIDTH;
+			while (_x >= Map.WIDTH) _x -= Map.WIDTH;
 			while (_y < 0) _y++;
-			while (_y + 11 >= Map.HEIGHT) _y--;
+			while (_y + _tilesY > Map.HEIGHT) _y--;
 			_update = true;
 			_fullRedraw = true;
 		}

--- a/src/Screens/NewGame.cs
+++ b/src/Screens/NewGame.cs
@@ -35,7 +35,8 @@ namespace CivOne.Screens
 
 		private int _difficulty = -1, _competition = -1, _tribe = -1;
 		private string _leaderName = null, _tribeName = null, _tribeNamePlural = null;
-		private bool _done = false, _showIntroText = false;
+		private bool _done = false, _showIntroText = false, _gameCreated = false, _introDirty = false;
+		private int _introBorderStyle = -1;
 		
 		private Menu CreateMenu(string title, MenuItemEventHandler<int> setChoice, params string[] menuTexts)
 		{
@@ -186,13 +187,19 @@ namespace CivOne.Screens
 			else if (_leaderName == null) InputLeaderName();
 			else if (!_done)
 			{
-				if (_showIntroText) return false;
-				
-				ICivilization civ = _tribesAvailable[_tribe];
-				Game.CreateGame(_difficulty, _competition, civ, _leaderName, _tribeName, _tribeNamePlural);
+				if (!_gameCreated)
+				{
+					ICivilization civ = _tribesAvailable[_tribe];
+					Game.CreateGame(_difficulty, _competition, civ, _leaderName, _tribeName, _tribeNamePlural, replaceExisting: true);
+					_gameCreated = true;
+					_introBorderStyle = Common.Random.Next(2);
+					_introDirty = true;
+				}
+
+				if (_showIntroText && !_introDirty) return false;
 				
 				this.Clear(15);
-				DrawBorder(Common.Random.Next(2));
+				DrawBorder(_introBorderStyle);
 				
 				this.AddLayer(DifficultyPicture, OffsetX + 134, OffsetY + 20);
 				
@@ -224,6 +231,7 @@ namespace CivOne.Screens
 				PlaySound(Human.Civilization.Tune);
 				
 				_showIntroText = true;
+				_introDirty = false;
 				return true;
 			}
 			else if (HandleScreenFadeOut())
@@ -315,7 +323,10 @@ namespace CivOne.Screens
 				input.X = OffsetX + 168;
 				input.Y = OffsetY + 105;
 			}
-			_showIntroText = false;
+			if (_showIntroText)
+			{
+				_introDirty = true;
+			}
 		}
 		
 		public NewGame() : base(MouseCursor.Pointer)

--- a/src/Screens/Overlay.cs
+++ b/src/Screens/Overlay.cs
@@ -10,6 +10,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using System;
 using CivOne.Enums;
 using CivOne.Events;
 using CivOne.Graphics;
@@ -19,6 +20,7 @@ using CivOne.Units;
 
 namespace CivOne.Screens
 {
+	[ScreenResizeable]
 	internal class Overlay : BaseScreen
 	{
 		private struct HelpLabel
@@ -50,28 +52,53 @@ namespace CivOne.Screens
 			{
 				IUnit startUnit = Game.GetUnits().First(x => Game.Human == x.Owner);
 				IUnit activeUnit = Game.ActiveUnit;
-				((GamePlay)Common.Screens.First(x => x is GamePlay)).Update(0);
-				int offset = 0;
+				GamePlay gamePlay = (GamePlay)Common.Screens.First(x => x is GamePlay);
+				gamePlay.Update(0);
+
+				IUnit focusUnit = (activeUnit != null && activeUnit.Owner == Game.PlayerNumber(Human)) ? activeUnit : startUnit;
+				int mapOffsetX = Settings.RightSideBar ? 0 : 80;
+				const int mapOffsetY = 8;
+				int mapWidth = Math.Max(0, gamePlay.Width() - 80);
+				int mapHeight = Math.Max(0, gamePlay.Height() - 8);
+				int mapCenterX = mapOffsetX + (mapWidth / 2);
+				int mapWindowPointX = Settings.RightSideBar
+					? mapOffsetX + Math.Max(8, mapWidth - 8)
+					: Math.Max(8, mapOffsetX - 32);
+				int mapWindowPointY = mapOffsetY + 24;
+				int referenceCenterX = Settings.RightSideBar ? 120 : 200;
+				int labelShiftX = mapCenterX - referenceCenterX;
+				int tilesX = Math.Max(1, (int)Math.Ceiling((double)mapWidth / 16));
+				int tilesY = Math.Max(1, (int)Math.Ceiling((double)mapHeight / 16));
+				int mapX = gamePlay.X;
+				int mapY = gamePlay.Y;
+
+				int activeRelX = focusUnit.X - mapX;
+				while (activeRelX < 0) activeRelX += Map.WIDTH;
+				while (activeRelX >= Map.WIDTH) activeRelX -= Map.WIDTH;
+				int activeRelY = focusUnit.Y - mapY;
+				int activePointX = mapOffsetX + (activeRelX * 16) + 8;
+				int activePointY = mapOffsetY + (activeRelY * 16) + 8;
 				if (Settings.RightSideBar)
 				{
-					yield return new HelpLabel("Map Window", 148, 24, 272, 32);
-					yield return new HelpLabel("Menu Bar", 61, 16, 160, 6);
-					yield return new HelpLabel("Active Unit", 158, 170, 280, 128);
-					offset = -80;
+					yield return new HelpLabel("Map Window", 148 + labelShiftX, 24, mapWindowPointX, mapWindowPointY);
+					yield return new HelpLabel("Menu Bar", 61 + labelShiftX, 16, 160 + labelShiftX, 6);
+					yield return new HelpLabel("Active Unit", 158 + labelShiftX, 170, activePointX, activePointY);
 				}
 				else
 				{
-					yield return new HelpLabel("Map Window", 88, 24, 48, 32);
-					yield return new HelpLabel("Menu Bar", 201, 16, 160, 6);
-					yield return new HelpLabel("Active Unit", 88, 170, 40, 128);
+					yield return new HelpLabel("Map Window", 88 + labelShiftX, 24, mapWindowPointX, mapWindowPointY);
+					yield return new HelpLabel("Menu Bar", 201 + labelShiftX, 16, 160 + labelShiftX, 6);
+					yield return new HelpLabel("Active Unit", 88 + labelShiftX, 170, activePointX, activePointY);
 				}
+
+				int labelCenterBaseX = mapCenterX - 30;
 				
 				for (int yy = -1; yy <= 1; yy++)
 				for (int xx = -1; xx <= 1; xx++)
 				{
 					if (xx == 0 && yy == 0) continue;
 					string text = string.Empty;
-					ITile tile = startUnit.Tile[xx, yy];
+					ITile tile = focusUnit.Tile[xx, yy];
 					switch (tile.Type)
 					{
 						case Terrain.Desert: text = (tile.Special ? "Oasis" : "Desert"); break;
@@ -89,7 +116,20 @@ namespace CivOne.Screens
 						case Terrain.Grassland2: text = "Grassland"; break;
 					}
 					if (tile.Hut) text = "Village";
-					yield return new HelpLabel(text, 170 + (65 * xx) + offset, 100 + (49 * yy), 200 + (xx * 16) + offset, 112 + (yy * 16));
+
+					int relX = tile.X - mapX;
+					while (relX < 0) relX += Map.WIDTH;
+					while (relX >= Map.WIDTH) relX -= Map.WIDTH;
+
+					int relY = tile.Y - mapY;
+					if (relX < 0 || relY < 0 || relX >= tilesX || relY >= tilesY)
+					{
+						continue;
+					}
+
+					int pointX = mapOffsetX + (relX * 16) + 8;
+					int pointY = mapOffsetY + (relY * 16) + 8;
+					yield return new HelpLabel(text, labelCenterBaseX + (65 * xx), 100 + (49 * yy), pointX, pointY);
 				}
 			}
 		}
@@ -104,6 +144,8 @@ namespace CivOne.Screens
 
 			if (_update)
 			{
+				this.Clear();
+
 				if (_interfaceHelp)
 				{
 					foreach (HelpLabel helpLabel in HelpLabels)
@@ -135,6 +177,12 @@ namespace CivOne.Screens
 				return true;
 			}
 			return false;
+		}
+
+		protected override void Resize(int width, int height)
+		{
+			base.Resize(width, height);
+			_update = true;
 		}
 		
 		public override bool KeyDown(KeyboardEventArgs args)

--- a/src/Screens/Setup.cs
+++ b/src/Screens/Setup.cs
@@ -397,19 +397,25 @@ namespace CivOne.Screens
 			MenuItem.Create("Back")
 		);
 
-		private void AutoSettlersMenu() => CreateMenu("Use auto settlers cheat", GotoMenu(BehaviorMenu, 1),
+		private void ComputerPlayerPathFindingMenu() => CreateMenu("Use smart pathfinding for computer players", GotoMenu(BehaviorMenu, 1),
+			MenuItem.Create($"{false.YesNo()}").OnSelect((s, a) => Settings.ComputerPlayerPathFinding = false).SetActive(() => !Settings.ComputerPlayerPathFinding),
+			MenuItem.Create($"{true.YesNo()} (default)").OnSelect((s, a) => Settings.ComputerPlayerPathFinding = true).SetActive(() => Settings.ComputerPlayerPathFinding),
+			MenuItem.Create("Back")
+		);
+
+		private void AutoSettlersMenu() => CreateMenu("Use auto settlers cheat", GotoMenu(BehaviorMenu, 2),
 			MenuItem.Create($"{false.YesNo()} (default)").OnSelect((s, a) => Settings.AutoSettlers = false).SetActive(() => !Settings.AutoSettlers),
 			MenuItem.Create(true.YesNo()).OnSelect((s, a) => Settings.AutoSettlers = true).SetActive(() => Settings.AutoSettlers),
 			MenuItem.Create("Back")
 		);
 
-		private void FastRiverMovementMenu() => CreateMenu("Movements on river like roads", GotoMenu(BehaviorMenu, 2),
+		private void FastRiverMovementMenu() => CreateMenu("Movements on river like roads", GotoMenu(BehaviorMenu, 3),
 			MenuItem.Create($"{false.YesNo()} (default)").OnSelect((s, a) => Settings.RiverFastMovement = false).SetActive(() => !Settings.RiverFastMovement),
 			MenuItem.Create(true.YesNo()).OnSelect((s, a) => Settings.RiverFastMovement = true).SetActive(() => Settings.RiverFastMovement),
 			MenuItem.Create("Back")
 		);
 
-		private void CanalCity() => CreateMenu("No movement penalty for sea units in city", GotoMenu(BehaviorMenu, 3),
+		private void CanalCity() => CreateMenu("No movement penalty for sea units in city", GotoMenu(BehaviorMenu, 4),
 			MenuItem.Create($"{false.YesNo()} (default)").OnSelect((s, a) => Settings.CanalCity = false).SetActive(() => !Settings.CanalCity),
 			MenuItem.Create(true.YesNo()).OnSelect((s, a) => Settings.CanalCity = true).SetActive(() => Settings.CanalCity),
 			MenuItem.Create("Back")
@@ -438,12 +444,13 @@ namespace CivOne.Screens
 		private void ExtendedGlobalWarmingMenu(int activeItem = 0) => CreateMenu("Extended global warming (needs savegame load)", activeItem,
 			MenuItem.Create($"Sea level rise: {Settings.IsGlobalWarmingFlagSet(Settings.GlobalWarmingFeatureFlag.SeaLevelRise).YesNo()}")
 				.OnSelect(GotoMenu(SeaLevelRise)),
-			MenuItem.Create("Back").OnSelect(GotoMenu(BehaviorMenu, 4))
+			MenuItem.Create("Back").OnSelect(GotoMenu(BehaviorMenu, 5))
 		);
 
 		private void BehaviorMenu(int activeItem = 0) => CreateMenu("Game behavior menu", activeItem,
 			[
 					MenuItem.Create($"Use smart PathFinding for \"goto\": {Settings.PathFinding.YesNo()}").OnSelect(GotoMenu(PathFindingMenu)),
+					MenuItem.Create($"Use smart pathfinding for computer players: {Settings.ComputerPlayerPathFinding.YesNo()}").OnSelect(GotoMenu(ComputerPlayerPathFindingMenu)),
 					MenuItem.Create($"Use auto-settlers-cheat: {Settings.AutoSettlers.YesNo()}").OnSelect(GotoMenu(AutoSettlersMenu)),
 					MenuItem.Create($"Use fast river movement: {Settings.RiverFastMovement.YesNo()}").OnSelect(GotoMenu(FastRiverMovementMenu)),
 					MenuItem.Create($"No movement penalty for sea units in city: {Settings.CanalCity.YesNo()}").OnSelect(GotoMenu(CanalCity)),

--- a/src/Screens/Setup.cs
+++ b/src/Screens/Setup.cs
@@ -38,12 +38,12 @@ namespace CivOne.Screens
 		[
 			("Auto (stretch)", -1, -1),
 
-			// SD / kleinere Formate
+			// SD
 			("640x360", 640, 360),
 			("854x480 (FWVGA)", 854, 480),
 			("960x540", 960, 540),
 
-			// HD / Standard
+			// HD
 			("1280x720 (HD)", 1280, 720),
 			("1366x768", 1366, 768),
 			("1600x900", 1600, 900),

--- a/src/Screens/Setup.cs
+++ b/src/Screens/Setup.cs
@@ -27,6 +27,88 @@ namespace CivOne.Screens
 	{
 		private const int MenuFont = 6;
 
+		/// <summary>
+		/// List of preset options for the "Expand Size" setting, which determines the target resolution when Aspect Ratio is set to Expand. 
+		/// The first option is always "Auto", which means the game will use the window size as the target resolution and stretch the canvas to fill it.
+		/// If you use the other options, be warned that parts of the game may be cut off if the window is smaller than the selected resolution, 
+		/// and that performance may be worse on lower-end hardware when using very high resolutions.
+		/// If you add new options here, make sure to update Settings.Max* values if necessary.
+		/// </summary>
+		private static readonly (string Label, int Width, int Height)[] ExpandSizeOptions =
+		[
+			("Auto (stretch)", -1, -1),
+
+			// SD / kleinere Formate
+			("640x360", 640, 360),
+			("854x480 (FWVGA)", 854, 480),
+			("960x540", 960, 540),
+
+			// HD / Standard
+			("1280x720 (HD)", 1280, 720),
+			("1366x768", 1366, 768),
+			("1600x900", 1600, 900),
+
+			// Full HD / WUXGA
+			("1920x1080 (FHD)", 1920, 1080),
+			("1920x1200 (WUXGA)", 1920, 1200),
+
+			// QHD / WQHD
+			("2560x1440 (QHD)", 2560, 1440),
+			("2560x1600 (WQXGA)", 2560, 1600),
+
+			// Ultrawide
+			("2560x1080 (UW-FHD)", 2560, 1080),
+			("3440x1440 (UW-QHD)", 3440, 1440),
+
+			// 4K / UHD
+			("3840x2160 (4K UHD)", 3840, 2160),
+			("4096x2160 (DCI 4K) (Warning: may be slow)", 4096, 2160),
+
+			// Higher resolutions
+			("5120x2880 (5K) (Warning: may be slow)", 5120, 2880),
+			("7680x4320 (8K UHD) (Warning: may be slow)", 7680, 4320)
+		];
+
+
+		/// <summary>
+		/// List of preset options for the "Window Size" setting, which determines the initial window size when the game is launched.
+		/// If you add new options here, make sure to update Settings.Max* values if necessary.
+		/// </summary>
+		private static readonly (string Label, int Width, int Height)[] WindowSizeOptions =
+		[
+			("Auto (scale-based)", -1, -1),
+
+			// Classic / small
+			("800x600 (SVGA)", 800, 600),
+			("1024x768 (XGA)", 1024, 768),
+
+			// HD range
+			("1280x720 (HD)", 1280, 720),
+			("1366x768", 1366, 768),
+			("1440x900 (WXGA+)", 1440, 900),
+			("1600x900", 1600, 900),
+
+			// Full HD
+			("1920x1080 (FHD)", 1920, 1080),
+			("1920x1200 (WUXGA)", 1920, 1200),
+
+			// QHD range
+			("2560x1440 (QHD)", 2560, 1440),
+			("2560x1600 (WQXGA)", 2560, 1600),
+
+			// Ultrawide
+			("2560x1080 (UW-FHD)", 2560, 1080),
+			("3440x1440 (UW-QHD)", 3440, 1440),
+
+			// 4K+
+			("3840x2160 (4K UHD) (Warning: may be slow)", 3840, 2160),
+			("4096x2160 (DCI 4K) (Warning: may be slow)", 4096, 2160),
+
+			// High-end
+			("5120x2880 (5K) (Warning: may be slow)", 5120, 2880),
+			("7680x4320 (8K UHD) (Warning: may be slow)", 7680, 4320)
+		];
+
 		private bool _update = true;
 
 		protected override bool HasUpdate(uint gameTick)
@@ -133,7 +215,9 @@ namespace CivOne.Screens
 			MenuItem.Create($"Window Title: {Settings.WindowTitle}").OnSelect(GotoScreen<WindowTitle>(ChangeWindowTitle)),
 			MenuItem.Create($"Graphics Mode: {Settings.GraphicsMode.ToText()}").OnSelect(GotoMenu(GraphicsModeMenu)),
 			MenuItem.Create($"Aspect Ratio: {Settings.AspectRatio.ToText()}").OnSelect(GotoMenu(AspectRatioMenu)),
+			MenuItem.Create($"Expand Size: {ExpandSizeText()}").OnSelect(GotoMenu(ExpandCanvasSizeMenu)),
 			MenuItem.Create($"Full Screen: {Settings.FullScreen.YesNo()}").OnSelect(GotoMenu(FullScreenMenu)),
+			MenuItem.Create($"Window Size: {WindowSizeText()}").OnSelect(GotoMenu(WindowSizeMenu)),
 			MenuItem.Create($"Window Scale: {Settings.Scale}x").OnSelect(GotoMenu(WindowScaleMenu)),
 			MenuItem.Create("In-game sound").OnSelect(GotoMenu(SoundMenu)),
 			MenuItem.Create($"Back").OnSelect(GotoMenu(MainMenu, 0))
@@ -154,13 +238,68 @@ namespace CivOne.Screens
 			MenuItem.Create("Back")
 		);
 
-		private void FullScreenMenu() => CreateMenu("Full Screen", GotoMenu(SettingsMenu, 3),
+		private string SizeText(int width, int height, string autoText)
+			=> width <= 0 || height <= 0 ? autoText : $"{width}x{height}";
+
+		private string ExpandSizeText() => SizeText(Settings.ExpandWidth, Settings.ExpandHeight, "Auto");
+
+		private void SetExpandSize(int width, int height)
+		{
+			Settings.ExpandWidth = width;
+			Settings.ExpandHeight = height;
+		}
+
+		private bool IsActiveSize(int currentWidth, int currentHeight, int optionWidth, int optionHeight)
+		{
+			if (optionWidth <= 0 || optionHeight <= 0)
+				return currentWidth <= 0 || currentHeight <= 0;
+			return currentWidth == optionWidth && currentHeight == optionHeight;
+		}
+
+		private MenuItem<int>[] BuildSizeMenuItems(
+			(string Label, int Width, int Height)[] options,
+			Func<int, int, bool> isActive,
+			Action<int, int> onSelect)
+			=>
+			[
+				.. options.Select(option =>
+					MenuItem.Create(option.Label)
+						.OnSelect((s, a) => onSelect(option.Width, option.Height))
+						.SetActive(() => isActive(option.Width, option.Height))),
+				MenuItem.Create("Back")
+			];
+
+		private void ExpandCanvasSizeMenu() => CreateMenu(
+			"Expand Size (only if Aspect Ratio is set to Expand)",
+			GotoMenu(SettingsMenu, 3),
+			BuildSizeMenuItems(
+				ExpandSizeOptions,
+				(width, height) => IsActiveSize(Settings.ExpandWidth, Settings.ExpandHeight, width, height),
+				SetExpandSize));
+
+		private void FullScreenMenu() => CreateMenu("Full Screen", GotoMenu(SettingsMenu, 4),
 			MenuItem.Create($"{false.YesNo()} (default)").OnSelect((s, a) => Settings.FullScreen = false).SetActive(() => !Settings.FullScreen),
 			MenuItem.Create(true.YesNo()).OnSelect((s, a) => Settings.FullScreen = true).SetActive(() => Settings.FullScreen),
 			MenuItem.Create("Back")
 		);
 
-		private void WindowScaleMenu() => CreateMenu("Window Scale", GotoMenu(SettingsMenu, 4),
+		private string WindowSizeText() => SizeText(Settings.WindowWidth, Settings.WindowHeight, "Auto");
+
+		private void SetWindowSizePreset(int width, int height)
+		{
+			Settings.WindowWidth = width;
+			Settings.WindowHeight = height;
+		}
+
+		private void WindowSizeMenu() => CreateMenu(
+			"Window Size",
+			GotoMenu(SettingsMenu, 5),
+			BuildSizeMenuItems(
+				WindowSizeOptions,
+				(width, height) => IsActiveSize(Settings.WindowWidth, Settings.WindowHeight, width, height),
+				SetWindowSizePreset));
+
+		private void WindowScaleMenu() => CreateMenu("Window Scale", GotoMenu(SettingsMenu, 6),
 			MenuItem.Create("1x").OnSelect((s, a) => Settings.Scale = 1).SetActive(() => Settings.Scale == 1),
 			MenuItem.Create("2x (default)").OnSelect((s, a) => Settings.Scale = 2).SetActive(() => Settings.Scale == 2),
 			MenuItem.Create("3x").OnSelect((s, a) => Settings.Scale = 3).SetActive(() => Settings.Scale == 3),
@@ -172,7 +311,7 @@ namespace CivOne.Screens
 			MenuItem.Create("Back")
 		);
 
-		private void SoundMenu() => CreateMenu("In-game sound", GotoMenu(SettingsMenu, 5),
+		private void SoundMenu() => CreateMenu("In-game sound", GotoMenu(SettingsMenu, 7),
 			MenuItem.Create("Browse for files...").OnSelect(BrowseForSoundFiles).SetEnabled(!FileSystem.SoundFilesExist()).SetEnabled(!Game.Started),
 			MenuItem.Create("Back")
 		);

--- a/src/Services/Pathfinding/AStarPathfinderAdapter.cs
+++ b/src/Services/Pathfinding/AStarPathfinderAdapter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Drawing;
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal sealed class AStarPathfinderAdapter : IPathfinder
+	{
+		public PathStepResult GetNextStep(IUnit unit, Point destination)
+		{
+			if (unit == null || destination.IsEmpty)
+			{
+				return PathStepResult.InvalidRequest();
+			}
+
+			AStar.sPosition goal = new()
+			{
+				iX = destination.X,
+				iY = destination.Y
+			};
+
+			AStar astar = new();
+			AStar.sPosition nextPosition = astar.FindPath(goal, unit);
+
+			if (nextPosition.iX < 0 || nextPosition.iY < 0)
+			{
+				return PathStepResult.NoPath();
+			}
+			if (nextPosition.iX == unit.X && nextPosition.iY == unit.Y)
+			{	
+				// explicitly return success if the unit is already at the destination.
+				return PathStepResult.Success(unit.X, unit.Y);
+			}
+
+			return PathStepResult.Success(nextPosition.iX, nextPosition.iY);
+		}
+	}
+
+	internal sealed class DisabledPathfinder : IPathfinder
+	{
+		public PathStepResult GetNextStep(IUnit unit, Point destination) => PathStepResult.Disabled();
+	}
+}

--- a/src/Services/Pathfinding/AiGotoExecutorFactory.cs
+++ b/src/Services/Pathfinding/AiGotoExecutorFactory.cs
@@ -1,0 +1,37 @@
+using System;
+using CivOne.Services.Random;
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal sealed class AiGotoExecutorFactory : IAiGotoExecutorFactory
+	{
+		private readonly Func<bool> _isComputerPlayerPathfindingEnabled;
+		private readonly IAiGotoExecutor _smartGotoExecutor;
+		private readonly IAiGotoExecutor _noOpGotoExecutor;
+
+		public AiGotoExecutorFactory(
+			Func<bool> isComputerPlayerPathfindingEnabled = null,
+			IAiGotoExecutor smartGotoExecutor = null,
+			IAiGotoExecutor noOpGotoExecutor = null,
+			IPathfinderFactory pathfinderFactory = null,
+			IRandomService randomService = null)
+		{
+			_isComputerPlayerPathfindingEnabled = isComputerPlayerPathfindingEnabled ?? (() => Settings.Instance.ComputerPlayerPathFinding);
+			IPathfinderFactory effectivePathfinderFactory = pathfinderFactory ?? IPathfinderFactory.Create();
+			IRandomService effectiveRandomService = randomService ?? RandomServiceFactory.Create();
+			_smartGotoExecutor = smartGotoExecutor ?? new SmartAiGotoExecutor(effectivePathfinderFactory, effectiveRandomService);
+			_noOpGotoExecutor = noOpGotoExecutor ?? new NoOpAiGotoExecutor();
+		}
+
+		public IAiGotoExecutor CreateFor(IUnit unit)
+		{
+			if (_isComputerPlayerPathfindingEnabled())
+			{
+				return _smartGotoExecutor;
+			}
+
+			return _noOpGotoExecutor;
+		}
+	}
+}

--- a/src/Services/Pathfinding/IAiGotoExecutor.cs
+++ b/src/Services/Pathfinding/IAiGotoExecutor.cs
@@ -1,0 +1,16 @@
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal enum AiGotoExecutionResult
+	{
+		NotHandled,
+		Continue,
+		TurnComplete
+	}
+
+	internal interface IAiGotoExecutor
+	{
+		AiGotoExecutionResult TryExecute(IUnit unit);
+	}
+}

--- a/src/Services/Pathfinding/IAiGotoExecutorFactory.cs
+++ b/src/Services/Pathfinding/IAiGotoExecutorFactory.cs
@@ -1,0 +1,11 @@
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal interface IAiGotoExecutorFactory
+	{
+		IAiGotoExecutor CreateFor(IUnit unit);
+
+		static IAiGotoExecutorFactory Create() => new AiGotoExecutorFactory();
+	}
+}

--- a/src/Services/Pathfinding/IPathfinder.cs
+++ b/src/Services/Pathfinding/IPathfinder.cs
@@ -1,0 +1,10 @@
+using System.Drawing;
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal interface IPathfinder
+	{
+		PathStepResult GetNextStep(IUnit unit, Point destination);
+	}
+}

--- a/src/Services/Pathfinding/IPathfinderFactory.cs
+++ b/src/Services/Pathfinding/IPathfinderFactory.cs
@@ -1,0 +1,11 @@
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal interface IPathfinderFactory
+	{
+		IPathfinder CreateFor(IUnit unit);
+
+		static IPathfinderFactory Create() => new PathfinderFactory();
+	}
+}

--- a/src/Services/Pathfinding/NoOpAiGotoExecutor.cs
+++ b/src/Services/Pathfinding/NoOpAiGotoExecutor.cs
@@ -1,0 +1,9 @@
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal sealed class NoOpAiGotoExecutor : IAiGotoExecutor
+	{
+		public AiGotoExecutionResult TryExecute(IUnit unit) => AiGotoExecutionResult.NotHandled;
+	}
+}

--- a/src/Services/Pathfinding/PathStepResult.cs
+++ b/src/Services/Pathfinding/PathStepResult.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal enum PathStepStatus
+	{
+		Success,
+		NoPath,
+		Disabled,
+		InvalidRequest
+	}
+
+	internal readonly record struct PathStepResult(PathStepStatus Status, int NextX, int NextY)
+	{
+		public bool HasStep => Status == PathStepStatus.Success;
+
+		public static PathStepResult Success(int nextX, int nextY) =>
+			new(PathStepStatus.Success, nextX, nextY);
+
+		public static PathStepResult NoPath() =>
+			new(PathStepStatus.NoPath, -1, -1);
+
+		public static PathStepResult Disabled() =>
+			new(PathStepStatus.Disabled, -1, -1);
+
+		public static PathStepResult InvalidRequest() =>
+			new(PathStepStatus.InvalidRequest, -1, -1);
+	}
+}

--- a/src/Services/Pathfinding/PathfinderFactory.cs
+++ b/src/Services/Pathfinding/PathfinderFactory.cs
@@ -1,0 +1,32 @@
+using System;
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal sealed class PathfinderFactory : IPathfinderFactory
+	{
+		private readonly Func<bool> _isComputerPlayerPathfindingEnabled;
+		private readonly IPathfinder _smartPathfinder;
+		private readonly IPathfinder _disabledPathfinder;
+
+		public PathfinderFactory(
+			Func<bool> isComputerPlayerPathfindingEnabled = null,
+			IPathfinder smartPathfinder = null,
+			IPathfinder disabledPathfinder = null)
+		{
+			_isComputerPlayerPathfindingEnabled = isComputerPlayerPathfindingEnabled ?? (() => Settings.Instance.ComputerPlayerPathFinding);
+			_smartPathfinder = smartPathfinder ?? new AStarPathfinderAdapter();
+			_disabledPathfinder = disabledPathfinder ?? new DisabledPathfinder();
+		}
+
+		public IPathfinder CreateFor(IUnit unit)
+		{
+			if (_isComputerPlayerPathfindingEnabled())
+			{
+				return _smartPathfinder;
+			}
+
+			return _disabledPathfinder;
+		}
+	}
+}

--- a/src/Services/Pathfinding/SmartAiGotoExecutor.cs
+++ b/src/Services/Pathfinding/SmartAiGotoExecutor.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using CivOne.Enums;
+using CivOne.Services.Random;
+using CivOne.Tiles;
+using CivOne.Units;
+
+namespace CivOne.Services.Pathfinding
+{
+	internal sealed class SmartAiGotoExecutor : IAiGotoExecutor
+	{
+		private readonly IPathfinderFactory _pathfinderFactory;
+		private readonly IRandomService _randomService;
+
+		public SmartAiGotoExecutor(IPathfinderFactory pathfinderFactory, IRandomService randomService)
+		{
+			_pathfinderFactory = pathfinderFactory ?? throw new ArgumentNullException(nameof(pathfinderFactory));
+			_randomService = randomService ?? throw new ArgumentNullException(nameof(randomService));
+		}
+
+		public AiGotoExecutionResult TryExecute(IUnit unit)
+		{
+			if (!CanHandle(unit))
+			{
+				return AiGotoExecutionResult.NotHandled;
+			}
+
+			PathStepResult pathStep = GetPathStep(unit);
+			if (pathStep.Status == PathStepStatus.Disabled)
+			{
+				return AiGotoExecutionResult.NotHandled;
+			}
+
+			if (!pathStep.HasStep)
+			{
+				return ResetGotoAndContinue(unit);
+			}
+
+			ITile nextTile = ResolveNextTile(unit, pathStep);
+			if (nextTile == null)
+			{
+				return ResetGotoAndContinue(unit);
+			}
+
+			if (ShouldCancelAttack(unit, nextTile))
+			{
+				return ResetGotoAndContinue(unit);
+			}
+
+			return TryMoveToNextStep(unit, pathStep);
+		}
+
+		private PathStepResult GetPathStep(IUnit unit)
+		{
+			IPathfinder pathfinder = _pathfinderFactory.CreateFor(unit);
+			return pathfinder.GetNextStep(unit, unit.Goto);
+		}
+
+		private static ITile ResolveNextTile(IUnit unit, PathStepResult pathStep) =>
+			unit.MoveTargets.FirstOrDefault(x => x.X == pathStep.NextX && x.Y == pathStep.NextY);
+
+		private static bool CanHandle(IUnit unit) => unit != null && !unit.Goto.IsEmpty;
+
+		private bool ShouldCancelAttack(IUnit unit, ITile nextTile)
+		{
+			if (!nextTile.Units.Any(x => x.Owner != unit.Owner))
+			{
+				return false;
+			}
+
+			if (unit.Role == UnitRole.Civilian || unit.Role == UnitRole.Settler || unit is Carrier)
+			{
+				return true;
+			}
+
+			if (unit.Role == UnitRole.Transport && _randomService.Next(0, 100) < 67)
+			{
+				return true;
+			}
+
+			if (unit.Attack < nextTile.Units.Max(x => x.Defense) && _randomService.Next(0, 100) < 50)
+			{
+				return true;
+			}
+
+			return false;
+		}
+
+		private AiGotoExecutionResult TryMoveToNextStep(IUnit unit, PathStepResult pathStep)
+		{
+			if (unit.MoveTo(pathStep.NextX - unit.X, pathStep.NextY - unit.Y))
+			{
+				return AiGotoExecutionResult.TurnComplete;
+			}
+
+			return HandleMoveFailure(unit);
+		}
+
+		private AiGotoExecutionResult HandleMoveFailure(IUnit unit)
+		{
+			if (_randomService.Next(0, 100) < 67)
+			{
+				return ResetGotoAndContinue(unit);
+			}
+
+			if (_randomService.Next(0, 100) < 67)
+			{
+				unit.SkipTurn();
+				return AiGotoExecutionResult.TurnComplete;
+			}
+
+			Game.Instance.DisbandUnit(unit);
+			return AiGotoExecutionResult.TurnComplete;
+		}
+
+		private static AiGotoExecutionResult ResetGotoAndContinue(IUnit unit)
+		{
+			unit.Goto = Point.Empty;
+			return AiGotoExecutionResult.Continue;
+		}
+	}
+}

--- a/src/Services/Random/CommonRandomService.cs
+++ b/src/Services/Random/CommonRandomService.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace CivOne.Services.Random
+{
+	internal sealed class CommonRandomService : IRandomService
+	{
+		private readonly Func<CivOne.Random> _randomAccessor;
+
+		public CommonRandomService(Func<CivOne.Random> randomAccessor)
+		{
+			_randomAccessor = randomAccessor ?? throw new ArgumentNullException(nameof(randomAccessor));
+		}
+
+		public int Next(int max) => _randomAccessor().Next(max);
+
+		public int Next(int min, int max) => _randomAccessor().Next(min, max);
+
+		public bool Hit(int percent) => _randomAccessor().Hit(percent);
+	}
+}

--- a/src/Services/Random/IRandomService.cs
+++ b/src/Services/Random/IRandomService.cs
@@ -1,0 +1,9 @@
+namespace CivOne.Services.Random
+{
+	internal interface IRandomService
+	{
+		int Next(int max);
+		int Next(int min, int max);
+		bool Hit(int percent);
+	}
+}

--- a/src/Services/Random/RandomServiceFactory.cs
+++ b/src/Services/Random/RandomServiceFactory.cs
@@ -1,0 +1,48 @@
+namespace CivOne.Services.Random
+{
+	/// <summary>
+	/// Use this factory to create an instance of <see cref="IRandomService"/>. 
+	/// The factory will cache the created instance and return the same instance on subsequent calls to <see cref="Create"/>. 
+	/// Use <see cref="Reset"/> to reset the cached instance with a new seed or to clear the cache.
+	/// </summary>
+	internal static class RandomServiceFactory
+	{
+		private static IRandomService _cached;
+
+		public static IRandomService Create()
+		{
+			if (_cached != null)
+			{
+				return _cached;
+			}
+
+			if (Common.Random == null)
+			{
+				Common.SetRandomSeed();
+			}
+
+			_cached = new CommonRandomService(() => Common.Random);
+			return _cached;
+		}
+
+		public static IRandomService Reset(ushort seed)
+		{
+			Common.SetRandomSeed(seed);
+			_cached = new CommonRandomService(() => Common.Random);
+			return _cached;
+		}
+
+		public static IRandomService Reset()
+		{
+			Common.SetRandomSeed();
+			_cached = new CommonRandomService(() => Common.Random);
+			return _cached;
+		}
+
+		internal static IRandomService Override(IRandomService randomService)
+		{
+			_cached = randomService;
+			return _cached;
+		}
+	}
+}

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -611,7 +611,7 @@ namespace CivOne
 			}
 			int windowPosX = -1;
 			int windowPosY = -1;
-			if (!GetSetting("WindowPosX", ref windowPosX, 0, MaxWindowWidth) || !GetSetting("WindowPosY", ref windowPosY, 0, MaxWindowHeight))
+			if (!GetSetting("WindowPosX", ref windowPosX, -MaxWindowWidth, MaxWindowWidth) || !GetSetting("WindowPosY", ref windowPosY, -MaxWindowHeight, MaxWindowHeight))
 			{
 				_windowPosition = new Point(-1, -1);
 			}

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -8,6 +8,7 @@
 // work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 using System;
+using System.Drawing;
 using System.IO;
 using CivOne.Enums;
 using CivOne.Graphics;
@@ -54,6 +55,8 @@ namespace CivOne
 		private GraphicsMode _graphicsMode = GraphicsMode.Graphics256;
 		private bool _fullScreen = false;
 		private int _windowWidth = -1, _windowHeight = -1;
+		private Point _windowPosition = new Point(-1, -1);
+		private bool _windowMaximized = false;
 		private bool _rightSideBar = false;
 		private int _scale = 2;
 		private AspectRatio _aspectRatio = AspectRatio.Auto;
@@ -141,6 +144,27 @@ namespace CivOne
 			{
 				_windowHeight = value;
 				SetSetting("WindowHeight", _windowHeight.ToString());
+			}
+		}
+
+		public Point WindowPosition
+		{
+			get => _windowPosition;
+			set
+			{
+				_windowPosition = value;
+				SetSetting("WindowPosX", _windowPosition.X.ToString());
+				SetSetting("WindowPosY", _windowPosition.Y.ToString());
+			}
+		}
+
+		public bool WindowMaximized
+		{
+			get => _windowMaximized;
+			set
+			{
+				_windowMaximized = value;
+				SetSetting("WindowMaximized", _windowMaximized ? "1" : "0");
 			}
 		}
 		
@@ -573,6 +597,17 @@ namespace CivOne
 				_windowWidth = -1;
 				_windowHeight = -1;
 			}
+			int windowPosX = -1;
+			int windowPosY = -1;
+			if (!GetSetting("WindowPosX", ref windowPosX, 0, MaxWindowWidth) || !GetSetting("WindowPosY", ref windowPosY, 0, MaxWindowHeight))
+			{
+				_windowPosition = new Point(-1, -1);
+			}
+			else
+			{
+				_windowPosition = new Point(windowPosX, windowPosY);
+			}
+			GetSetting("WindowMaximized", ref _windowMaximized);
 			GetSetting<AspectRatio>("AspectRatio", ref _aspectRatio);
 			GetSetting("Sound", ref _sound);
 			if (!GetSetting("ExpandWidth", ref _expandWidth, MinWidth, MaxExpandWidth) || !GetSetting("ExpandHeight", ref _expandHeight, MinHeight, MaxExpandHeight))

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -67,6 +67,7 @@ namespace CivOne
 		private bool _arrowHelper = false;
 		private bool _customMapSize = false;
 		private bool _pathFinding = false;
+		private bool _computerPlayerPathFinding = true;
 		private bool _riverFastMovement = false;
 		private bool _canalCity = false;
 		private bool _preferSveSaveFormat = true;
@@ -291,6 +292,17 @@ namespace CivOne
 			{
 				_pathFinding = value;
 				SetSetting("PathFindingAlgorithm", _pathFinding ? "1" : "0");
+				Common.ReloadSettings = true;
+			}
+		}
+
+		internal bool ComputerPlayerPathFinding
+		{
+			get => _computerPlayerPathFinding;
+			set
+			{
+				_computerPlayerPathFinding = value;
+				SetSetting("ComputerPlayerPathFindingAlgorithm", _computerPlayerPathFinding ? "1" : "0");
 				Common.ReloadSettings = true;
 			}
 		}
@@ -621,6 +633,7 @@ namespace CivOne
 			GetSetting("ArrowHelper", ref _arrowHelper);
 			GetSetting("CustomMapSize", ref _customMapSize);
 			GetSetting("PathFindingAlgorithm", ref _pathFinding);
+			GetSetting("ComputerPlayerPathFindingAlgorithm", ref _computerPlayerPathFinding);
 			GetSetting("AutoSettlers", ref _autoSettlers);
 			GetSetting("RiverFastMovement", ref _riverFastMovement);
 			GetSetting("CanalCity", ref _canalCity);

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -21,10 +21,39 @@ namespace CivOne
 		private static IRuntime Runtime => RuntimeHandler.Runtime;
 		//private static void Log(string text, params object[] parameters) => RuntimeHandler.Runtime.Log(text, parameters);
 
+		// ── Window / OS canvas ────────────────────────────────────────────────
+		// Hard limits for the physical OS window size and the raw SDL canvas.
+		public const int MinWidth  = 320;
+		public const int MinHeight = 200;
+		public const int MaxWindowWidth  = 7680;  // maximum OS window width  (8K)
+		public const int MaxWindowHeight = 4320;  // maximum OS window height (8K)
+
+		// ── Expand mode stored values ──────────────────────────────────────
+		// Upper bound for the ExpandWidth / ExpandHeight values that the user
+		// can configure and that are persisted in the profile.  These may be
+		// as large as the largest supported display.
+		public const int MaxExpandWidth  = 7680;
+		public const int MaxExpandHeight = 4320;
+
+		// ── Effective gameplay surface ─────────────────────────────────────
+		// Cap on the logical canvas size that game-logic code (tile counts,
+		// map queries, etc.) ever sees via RuntimeHandler.CanvasWidth/Height.
+		// Keeping this small prevents _tilesX/_tilesY from growing beyond what
+		// Map.QueryMapPart can safely handle.
+		public const int MaxScreenWidth  = 512;
+		public const int MaxScreenHeight = 384;
+
+		// ── Auto-expand fallback ───────────────────────────────────────────
+		// When AspectRatio=Auto and no explicit expand size is stored, the
+		// canvas is capped to these values instead of the full window size.
+		public const int AutoExpandMaxWidth  = 1280;
+		public const int AutoExpandMaxHeight = 720;
+
 		// Set default settings
 		private string _windowTitle = "CivOne";
 		private GraphicsMode _graphicsMode = GraphicsMode.Graphics256;
 		private bool _fullScreen = false;
+		private int _windowWidth = -1, _windowHeight = -1;
 		private bool _rightSideBar = false;
 		private int _scale = 2;
 		private AspectRatio _aspectRatio = AspectRatio.Auto;
@@ -92,6 +121,26 @@ namespace CivOne
 				_fullScreen = value;
 				SetSetting("FullScreen", _fullScreen ? "1" : "0");
 				Common.ReloadSettings = true;
+			}
+		}
+
+		public int WindowWidth
+		{
+			get => _windowWidth;
+			set
+			{
+				_windowWidth = value;
+				SetSetting("WindowWidth", _windowWidth.ToString());
+			}
+		}
+
+		public int WindowHeight
+		{
+			get => _windowHeight;
+			set
+			{
+				_windowHeight = value;
+				SetSetting("WindowHeight", _windowHeight.ToString());
 			}
 		}
 		
@@ -519,9 +568,14 @@ namespace CivOne
 			GetSetting("FullScreen", ref _fullScreen);
 			GetSetting("SideBar", ref _rightSideBar);
 			GetSetting("Scale", ref _scale, 1, 8);
+			if (!GetSetting("WindowWidth", ref _windowWidth, MinWidth, MaxWindowWidth) || !GetSetting("WindowHeight", ref _windowHeight, MinHeight, MaxWindowHeight))
+			{
+				_windowWidth = -1;
+				_windowHeight = -1;
+			}
 			GetSetting<AspectRatio>("AspectRatio", ref _aspectRatio);
 			GetSetting("Sound", ref _sound);
-			if (!GetSetting("ExpandWidth", ref _scale, 320, 512) || !GetSetting("ExpandHeight", ref _scale, 200, 384))
+			if (!GetSetting("ExpandWidth", ref _expandWidth, MinWidth, MaxExpandWidth) || !GetSetting("ExpandHeight", ref _expandHeight, MinHeight, MaxExpandHeight))
 			{
 				_expandWidth = -1;
 				_expandHeight = -1;

--- a/xunit/src/AiGotoExecutorTests.cs
+++ b/xunit/src/AiGotoExecutorTests.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using CivOne.Services.Pathfinding;
+using CivOne.Services.Random;
+using CivOne.Tiles;
+using CivOne.Units;
+using Xunit;
+
+namespace CivOne.UnitTests
+{
+	public class AiGotoExecutorTests
+	{
+		[Fact]
+		public void CreateFor_WhenComputerPathfindingEnabled_ReturnsSmartExecutor()
+		{
+			// Arrange
+			IAiGotoExecutor expected = new StubExecutor(AiGotoExecutionResult.NotHandled);
+			IAiGotoExecutor fallback = new StubExecutor(AiGotoExecutionResult.NotHandled);
+			IRandomService randomService = new StubRandomService();
+			var testee = new AiGotoExecutorFactory(() => true, expected, fallback, randomService: randomService);
+
+			// Act
+			IAiGotoExecutor actual = testee.CreateFor(new MockedIUnit());
+
+			// Assert
+			Assert.Same(expected, actual);
+		}
+
+		[Fact]
+		public void CreateFor_WhenComputerPathfindingDisabled_ReturnsNoOpExecutor()
+		{
+			// Arrange
+			IAiGotoExecutor smart = new StubExecutor(AiGotoExecutionResult.NotHandled);
+			IAiGotoExecutor expected = new StubExecutor(AiGotoExecutionResult.NotHandled);
+			IRandomService randomService = new StubRandomService();
+			var testee = new AiGotoExecutorFactory(() => false, smart, expected, randomService: randomService);
+
+			// Act
+			IAiGotoExecutor actual = testee.CreateFor(new MockedIUnit());
+
+			// Assert
+			Assert.Same(expected, actual);
+		}
+
+		[Fact]
+		public void TryExecute_WhenUnitIsNull_ReturnsNotHandled()
+		{
+			// Arrange
+			var testee = CreateSmartExecutor(PathStepResult.Disabled());
+
+			// Act
+			AiGotoExecutionResult actual = testee.TryExecute(null);
+
+			// Assert
+			Assert.Equal(AiGotoExecutionResult.NotHandled, actual);
+		}
+
+		[Fact]
+		public void TryExecute_WhenUnitGotoIsEmpty_ReturnsNotHandled()
+		{
+			// Arrange
+			TestUnit unit = new() { Goto = Point.Empty };
+			var testee = CreateSmartExecutor(PathStepResult.Disabled());
+
+			// Act
+			AiGotoExecutionResult actual = testee.TryExecute(unit);
+
+			// Assert
+			Assert.Equal(AiGotoExecutionResult.NotHandled, actual);
+		}
+
+		[Fact]
+		public void TryExecute_WhenPathfinderDisabled_ReturnsNotHandled()
+		{
+			// Arrange
+			TestUnit unit = new() { Goto = new Point(12, 10) };
+			var testee = CreateSmartExecutor(PathStepResult.Disabled());
+
+			// Act
+			AiGotoExecutionResult actual = testee.TryExecute(unit);
+
+			// Assert
+			Assert.Equal(AiGotoExecutionResult.NotHandled, actual);
+		}
+
+		[Fact]
+		public void TryExecute_WhenNoPath_ClearsGotoAndReturnsContinue()
+		{
+			// Arrange
+			TestUnit unit = new() { Goto = new Point(12, 10) };
+			var testee = CreateSmartExecutor(PathStepResult.NoPath());
+
+			// Act
+			AiGotoExecutionResult actual = testee.TryExecute(unit);
+
+			// Assert
+			Assert.Equal(AiGotoExecutionResult.Continue, actual);
+			Assert.Equal(Point.Empty, unit.Goto);
+		}
+
+		[Fact]
+		public void TryExecute_WhenPathStepTileNotReachable_ClearsGotoAndReturnsContinue()
+		{
+			// Arrange
+			TestUnit unit = new() { Goto = new Point(12, 10), MoveTargets = [] };
+			var testee = CreateSmartExecutor(PathStepResult.Success(12, 10));
+
+			// Act
+			AiGotoExecutionResult actual = testee.TryExecute(unit);
+
+			// Assert
+			Assert.Equal(AiGotoExecutionResult.Continue, actual);
+			Assert.Equal(Point.Empty, unit.Goto);
+		}
+
+		[Fact]
+		public void TryExecute_WhenCivilianWouldAttack_ClearsGotoAndReturnsContinue()
+		{
+			// Arrange
+			var enemy = new MockedIUnit { Owner = 2 };
+			ITile targetTile = new MockedGrassland(11, 10).WithUnits(enemy);
+			TestUnit unit = new()
+			{
+				Owner = 1,
+				Role = CivOne.Enums.UnitRole.Civilian,
+				Goto = new Point(11, 10),
+				MoveTargets = [targetTile]
+			};
+			var testee = CreateSmartExecutor(PathStepResult.Success(11, 10));
+
+			// Act
+			AiGotoExecutionResult actual = testee.TryExecute(unit);
+
+			// Assert
+			Assert.Equal(AiGotoExecutionResult.Continue, actual);
+			Assert.Equal(Point.Empty, unit.Goto);
+		}
+
+		[Fact]
+		public void TryExecute_WhenMoveSucceeds_ReturnsTurnComplete()
+		{
+			// Arrange
+			ITile targetTile = new MockedGrassland(11, 10);
+			TestUnit unit = new()
+			{
+				Owner = 1,
+				X = 10,
+				Y = 10,
+				Goto = new Point(11, 10),
+				MoveTargets = [targetTile],
+				MoveToHandler = (_, _) => true
+			};
+			var testee = CreateSmartExecutor(PathStepResult.Success(11, 10));
+
+			// Act
+			AiGotoExecutionResult actual = testee.TryExecute(unit);
+
+			// Assert
+			Assert.Equal(AiGotoExecutionResult.TurnComplete, actual);
+			Assert.Equal(1, unit.LastMoveRelX);
+			Assert.Equal(0, unit.LastMoveRelY);
+		}
+
+		private static SmartAiGotoExecutor CreateSmartExecutor(PathStepResult result)
+		{
+			var pathfinder = new StubPathfinder(result);
+			var pathfinderFactory = new StubPathfinderFactory(pathfinder);
+			var randomService = new StubRandomService();
+			return new SmartAiGotoExecutor(pathfinderFactory, randomService);
+		}
+
+		private sealed class StubExecutor : IAiGotoExecutor
+		{
+			private readonly AiGotoExecutionResult _result;
+
+			public StubExecutor(AiGotoExecutionResult result)
+			{
+				_result = result;
+			}
+
+			public AiGotoExecutionResult TryExecute(IUnit unit) => _result;
+		}
+
+		private sealed class StubPathfinderFactory : IPathfinderFactory
+		{
+			private readonly IPathfinder _pathfinder;
+
+			public StubPathfinderFactory(IPathfinder pathfinder)
+			{
+				_pathfinder = pathfinder;
+			}
+
+			public IPathfinder CreateFor(IUnit unit) => _pathfinder;
+		}
+
+		private sealed class StubPathfinder : IPathfinder
+		{
+			private readonly PathStepResult _result;
+
+			public StubPathfinder(PathStepResult result)
+			{
+				_result = result;
+			}
+
+			public PathStepResult GetNextStep(IUnit unit, Point destination) => _result;
+		}
+
+		private sealed class StubRandomService : IRandomService
+		{
+			public int Next(int max) => 0;
+
+			public int Next(int min, int max) => min;
+
+			public bool Hit(int percent) => percent > 0;
+		}
+
+		private sealed class TestUnit : MockedIUnit, IUnit
+		{
+			public Func<int, int, bool> MoveToHandler { get; set; } = (_, _) => true;
+			public int LastMoveRelX { get; private set; }
+			public int LastMoveRelY { get; private set; }
+			public bool SkipTurnCalled { get; private set; }
+
+			bool IUnit.MoveTo(int relX, int relY)
+			{
+				LastMoveRelX = relX;
+				LastMoveRelY = relY;
+				return MoveToHandler(relX, relY);
+			}
+
+			void IUnit.SkipTurn()
+			{
+				SkipTurnCalled = true;
+			}
+		}
+	}
+}

--- a/xunit/src/ContinentTraversalDelegateTests.cs
+++ b/xunit/src/ContinentTraversalDelegateTests.cs
@@ -1,0 +1,140 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+using Xunit;
+
+namespace CivOne.UnitTests
+{
+    public class ContinentTraversalDelegateTests
+    {
+        private readonly int[,] _aiRelPos = { { -1, 0 }, { 0, -1 }, { 0, 1 }, { 1, 0 } };
+
+        [Fact]
+        public void CountContinent_WrapsHorizontallyAcrossMapEdge()
+        {
+            // Arrange
+            const int width = 5;
+            const int height = 3;
+            bool[,] ocean =
+            {
+                { true, true, true },
+                { true, true, true },
+                { true, true, true },
+                { true, true, true },
+                { true, true, true }
+            };
+            byte[,] continentIds = new byte[width, height];
+            ocean[0, 1] = false;
+            ocean[4, 1] = false;
+
+            ContinentTraversalDelegate _testee = CreateTestee(width, height, ocean, continentIds);
+
+            // Act
+            ulong actual = _testee.CountContinent(0, 1, ocean: false, continentId: 7);
+
+            // Assert
+            Assert.Equal((ulong)2, actual);
+            Assert.Equal((byte)7, continentIds[0, 1]);
+            Assert.Equal((byte)7, continentIds[4, 1]);
+        }
+
+        [Fact]
+        public void CountContinent_DoesNotWrapVertically()
+        {
+            // Arrange
+            const int width = 5;
+            const int height = 3;
+            bool[,] ocean =
+            {
+                { true, true, true },
+                { true, true, true },
+                { true, true, true },
+                { true, true, true },
+                { true, true, true }
+            };
+            byte[,] continentIds = new byte[width, height];
+            ocean[2, 0] = false;
+            ocean[2, 2] = false;
+
+            ContinentTraversalDelegate _testee = CreateTestee(width, height, ocean, continentIds);
+
+            // Act
+            ulong actual = _testee.CountContinent(2, 0, ocean: false, continentId: 3);
+
+            // Assert
+            Assert.Equal((ulong)1, actual);
+            Assert.Equal((byte)3, continentIds[2, 0]);
+            Assert.Equal((byte)0, continentIds[2, 2]);
+        }
+
+        [Fact]
+        public void CountContinent_SkipsAlreadyAssignedTiles()
+        {
+            // Arrange
+            const int width = 4;
+            const int height = 3;
+            bool[,] ocean =
+            {
+                { true, true, true },
+                { true, true, true },
+                { true, true, true },
+                { true, true, true }
+            };
+            byte[,] continentIds = new byte[width, height];
+            ocean[0, 1] = false;
+            ocean[1, 1] = false;
+            ocean[2, 1] = false;
+            continentIds[1, 1] = 9;
+
+            ContinentTraversalDelegate _testee = CreateTestee(width, height, ocean, continentIds);
+
+            // Act
+            ulong actual = _testee.CountContinent(0, 1, ocean: false, continentId: 2);
+
+            // Assert
+            Assert.Equal((ulong)1, actual);
+            Assert.Equal((byte)2, continentIds[0, 1]);
+            Assert.Equal((byte)9, continentIds[1, 1]);
+            Assert.Equal((byte)0, continentIds[2, 1]);
+        }
+
+        [Fact]
+        public void CountContinent_ReturnsZeroForMismatchingStartTileType()
+        {
+            // Arrange
+            const int width = 3;
+            const int height = 3;
+            bool[,] ocean =
+            {
+                { true, true, true },
+                { true, true, true },
+                { true, true, true }
+            };
+            byte[,] continentIds = new byte[width, height];
+
+            ContinentTraversalDelegate _testee = CreateTestee(width, height, ocean, continentIds);
+
+            // Act
+            ulong actual = _testee.CountContinent(1, 1, ocean: false, continentId: 1);
+
+            // Assert
+            Assert.Equal((ulong)0, actual);
+            Assert.Equal((byte)0, continentIds[1, 1]);
+        }
+
+        private ContinentTraversalDelegate CreateTestee(int width, int height, bool[,] ocean, byte[,] continentIds)
+            => new ContinentTraversalDelegate(
+                width,
+                height,
+                _aiRelPos,
+                (x, y) => ocean[x, y],
+                (x, y) => continentIds[x, y],
+                (x, y, continentId) => continentIds[x, y] = continentId);
+    }
+}

--- a/xunit/src/PlayerWarTests.cs
+++ b/xunit/src/PlayerWarTests.cs
@@ -1,7 +1,8 @@
-namespace CivOne.src
+namespace CivOne.UnitTests
 {
 	using System.Linq;
 	using CivOne.Civilizations;
+	using CivOne.src;
 	using Xunit;
 
 	public class PlayerWarTests : TestsBase

--- a/xunit/src/PlayerWarTests.cs
+++ b/xunit/src/PlayerWarTests.cs
@@ -1,0 +1,106 @@
+namespace CivOne.src
+{
+	using System.Linq;
+	using CivOne.Civilizations;
+	using Xunit;
+
+	public class PlayerWarTests : TestsBase
+	{
+		[Fact]
+		public void IsAtWar_WhenSetAtWarWasNeverCalled_ReturnsFalse()
+		{
+			// Arrange
+			var players = GetNonBarbarianPlayers(Game.Instance, 2);
+			var player = players[0];
+			var enemy = players[1];
+
+			// Act
+			var actual = player.IsAtWar(enemy);
+
+			// Assert
+			Assert.False(actual);
+		}
+
+		[Fact]
+		public void SetAtWar_WhenCalledTwiceWithTrue_RemainsAtWar()
+		{
+			// Arrange
+			var players = GetNonBarbarianPlayers(Game.Instance, 2);
+			var player = players[0];
+			var enemy = players[1];
+			var enemyNumber = Game.Instance.PlayerNumber(enemy);
+
+			// Act
+			player.SetAtWar(enemyNumber, true);
+			player.SetAtWar(enemyNumber, true);
+			var actual = player.IsAtWar(enemy);
+
+			// Assert
+			Assert.True(actual);
+		}
+
+		[Fact]
+		public void DeclareWar_WhenCalled_SetsSymmetricWarState()
+		{
+			// Arrange
+			var players = GetNonBarbarianPlayers(Game.Instance, 2);
+			var attacker = players[0];
+			var defender = players[1];
+
+			// Act
+			attacker.DeclareWar(defender);
+			var attackerView = attacker.IsAtWar(defender);
+			var defenderView = defender.IsAtWar(attacker);
+
+			// Assert
+			Assert.True(attackerView);
+			Assert.True(defenderView);
+		}
+
+		[Fact]
+		public void MakePeace_AfterDeclareWar_ClearsSymmetricWarState()
+		{
+			// Arrange
+			var players = GetNonBarbarianPlayers(Game.Instance, 2);
+			var playerA = players[0];
+			var playerB = players[1];
+			playerA.DeclareWar(playerB);
+
+			// Act
+			playerA.MakePeace(playerB);
+			var aView = playerA.IsAtWar(playerB);
+			var bView = playerB.IsAtWar(playerA);
+
+			// Assert
+			Assert.False(aView);
+			Assert.False(bView);
+		}
+
+		[Fact]
+		public void DeclareWar_WhenEnemyIsBarbarian_DoesNotCreateFormalWarState()
+		{
+			// Arrange
+			var player = GetNonBarbarianPlayers(Game.Instance, 1).Single();
+			var barbarian = Game.Instance.GetPlayer(0);
+
+			// Act
+			player.DeclareWar(barbarian);
+			var actual = player.IsAtWar(barbarian);
+
+			// Assert
+			Assert.False(actual);
+		}
+
+		private static Player[] GetNonBarbarianPlayers(Game game, int count)
+		{
+			var players = Enumerable.Range(0, 8)
+				.Select(index => game.GetPlayer((byte)index))
+				.Where(player => player != null && player.Civilization is not Barbarian)
+				.Take(count)
+				.ToArray();
+
+			Assert.True(players.Length >= count, $"Expected at least {count} non-barbarian players in test setup.");
+			return players;
+		}
+	}
+}

--- a/xunit/src/PlayerWarTests.cs
+++ b/xunit/src/PlayerWarTests.cs
@@ -91,9 +91,57 @@ namespace CivOne.src
 			Assert.False(actual);
 		}
 
+		[Fact]
+		public void DeclareWar_WhenTradingCitiesExistBetweenParties_PurgesThemOnBothSides()
+		{
+			// Arrange
+			var players = GetNonBarbarianPlayers(Game.Instance, 2);
+			var attacker = players[0];
+			var defender = players[1];
+			City attackerCity = Game.Instance.AddCity(attacker, 0, 40, 30);
+			City defenderCity = Game.Instance.AddCity(defender, 1, 42, 30);
+
+			attackerCity.AddTradingCity(defenderCity);
+			defenderCity.AddTradingCity(attackerCity);
+
+			// Act
+			attacker.DeclareWar(defender);
+
+			// Assert
+			Assert.DoesNotContain(defenderCity, attackerCity.TradingCitiesAsCity);
+			Assert.DoesNotContain(attackerCity, defenderCity.TradingCitiesAsCity);
+		}
+
+		[Fact]
+		public void DeclareWar_WhenThirdPartyTradingCitiesExist_LeavesThoseUntouched()
+		{
+			// Arrange
+			var players = GetNonBarbarianPlayers(Game.Instance, 2);
+			var attacker = players[0];
+			var defender = players[1];
+			var thirdParty = Game.Instance.GetPlayer(0);
+			City attackerCity = Game.Instance.AddCity(attacker, 2, 44, 30);
+			City defenderCity = Game.Instance.AddCity(defender, 3, 46, 30);
+			City thirdPartyCity = Game.Instance.AddCity(thirdParty, 4, 48, 30);
+
+			attackerCity.AddTradingCity(defenderCity);
+			attackerCity.AddTradingCity(thirdPartyCity);
+			defenderCity.AddTradingCity(attackerCity);
+			defenderCity.AddTradingCity(thirdPartyCity);
+
+			// Act
+			attacker.DeclareWar(defender);
+
+			// Assert
+			Assert.DoesNotContain(defenderCity, attackerCity.TradingCitiesAsCity);
+			Assert.DoesNotContain(attackerCity, defenderCity.TradingCitiesAsCity);
+			Assert.Contains(thirdPartyCity, attackerCity.TradingCitiesAsCity);
+			Assert.Contains(thirdPartyCity, defenderCity.TradingCitiesAsCity);
+		}
+
 		private static Player[] GetNonBarbarianPlayers(Game game, int count)
 		{
-			var players = Enumerable.Range(0, 8)
+			var players = Enumerable.Range(0, game.Players.Count())
 				.Select(index => game.GetPlayer((byte)index))
 				.Where(player => player != null && player.Civilization is not Barbarian)
 				.Take(count)

--- a/xunit/src/RandomServiceFactoryTests.cs
+++ b/xunit/src/RandomServiceFactoryTests.cs
@@ -1,0 +1,79 @@
+using CivOne.Services.Random;
+using Xunit;
+
+namespace CivOne.UnitTests
+{
+	public class RandomServiceFactoryTests
+	{
+		[Fact]
+		public void Create_WhenServiceWasOverridden_ReturnsSameCachedInstance()
+		{
+			// Arrange
+			IRandomService expected = new StubRandomService();
+			RandomServiceFactory.Override(expected);
+
+			// Act
+			IRandomService actual = RandomServiceFactory.Create();
+
+			// Assert
+			Assert.Same(expected, actual);
+		}
+
+		[Fact]
+		public void Override_WhenCalledTwice_ReplacesCachedInstance()
+		{
+			// Arrange
+			IRandomService oldService = new StubRandomService();
+			IRandomService expected = new StubRandomService();
+			RandomServiceFactory.Override(oldService);
+
+			// Act
+			RandomServiceFactory.Override(expected);
+			IRandomService actual = RandomServiceFactory.Create();
+
+			// Assert
+			Assert.Same(expected, actual);
+			Assert.NotSame(oldService, actual);
+		}
+
+		[Fact]
+		public void Next_WhenCalled_ReturnsValueFromWrappedRandomInstance()
+		{
+			// Arrange
+			var random = new Random(1234);
+			var testee = new CommonRandomService(() => random);
+
+			// Act
+			int expected = random.Next(0, 100);
+			random = new Random(1234);
+			testee = new CommonRandomService(() => random);
+			int actual = testee.Next(0, 100);
+
+			// Assert
+			Assert.Equal(expected, actual);
+		}
+
+		[Fact]
+		public void Hit_WhenPercentIsZero_ReturnsFalse()
+		{
+			// Arrange
+			var random = new Random(23905);
+			var testee = new CommonRandomService(() => random);
+
+			// Act
+			bool actual = testee.Hit(0);
+
+			// Assert
+			Assert.False(actual);
+		}
+
+		private sealed class StubRandomService : IRandomService
+		{
+			public int Next(int max) => 0;
+
+			public int Next(int min, int max) => min;
+
+			public bool Hit(int percent) => percent > 0;
+		}
+	}
+}

--- a/xunit/src/persistence/SaveDataAdapterTests.cs
+++ b/xunit/src/persistence/SaveDataAdapterTests.cs
@@ -9,6 +9,22 @@ namespace CivOne.UnitTests.Persistence
 	public class SaveDataAdapterTests : TestsBase
 	{
 		[Fact]
+		public void CivilizationIdentity_SetterAndGetter_RoundtripFlagsWithoutBitShiftRegression()
+		{
+			// Arrange
+			using var _testee = new SaveDataAdapter();
+			byte[] expected = [1, 0, 1, 1, 0, 1, 0, 1];
+
+			// Act
+			_testee.CivilizationIdentity = expected;
+			using var actualAdapter = SaveDataAdapter.Load(_testee.GetBytes());
+			byte[] actual = actualAdapter.CivilizationIdentity;
+
+			// Assert
+			Assert.Equal(expected, actual);
+		}
+
+		[Fact]
 		public void Cities_Setter_PreservesVisibleSizeInBinarySaveData()
 		{
 			// Arrange


### PR DESCRIPTION
Migration of mwerneburg/CivOne.

The migration is now finished in the planned scope. That does not mean every single change from the mwern branch was copied 1:1. The goal was to migrate the important and stable parts, while keeping the current architecture clean and avoiding risky changes.

The main completed work includes the core war and diplomacy status logic: bilateral war relations between players, proper DeclareWar / MakePeace behavior, removal of trade connections when war starts, and related test coverage. In general, existing systems in this project were kept if they already solved the same problem in a good way.

Some parts were not migrated on purpose:

* the full King / diplomacy UI, because the legacy diplomacy save bits are still unclear,
* most AI strategy changes, because they are more like optional AI improvements,
* the production queue, because it looks like a mwern convenience feature, not core original behavior,
* the binary save and sidecar extensions, because this project already uses YAML persistence for that area,
* the full CityManager redesign, because it would be a large and risky rewrite.

So in short: the migration is finished, but selective. Core gameplay-related parts were integrated, existing solutions were respected, and risky or non-essential mwern features were left out on purpose.

