### PR TITLE
Translate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,20 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
-* Feature: Added `civtranslate` CLI tool to scan `*.cs` files for translation calls and update key-value translation files.
-  * Scans for `.Translate("...")`, `.TranslateFormatted("...", ...)`, and `T("...")`.
-  * Normalizes keys to uppercase while keeping values as source text.
-  * Writes `key=value` entries and escapes literal `=` as `[EQ]`.
-  * Merges with existing output files, overwrites existing values for found keys, and prints old/new value changes.
-  * Writes obsolete keys to `obsoletekeys.txt` in the output directory.
+* Feature: Translation system with multi-language support
+  * In-game translation is now active.
+  * Language can be changed in the setup menu via `Shift+F1` -> `Game Options` -> `Language`.
+  * The selected language is applied through `TranslationServiceFactory` and reused by gameplay and UI services.
+  * `civtranslate` CLI tool scans `*.cs` files for translation calls and creates/updates translation key-value files.
+    * Scans for `.Translate("...")`, `.TranslateFormatted("...", ...)`, and `T("...")` patterns.
+    * Normalizes keys to uppercase while keeping values as source text.
+    * Writes `key=value` entries and escapes literal `=` as `[EQ]`.
+    * Merges with existing output files, preserving comments and handling value overwrites.
+    * Writes obsolete keys to `obsoletekeys.txt` in the output directory.
+    * Translation files support comment headers (lines starting with `#`).
+    * Existing comment headers are preserved when updating files.
+  * Translation loader ignores `#` comment lines in language files.
+  * `SaveMetaDataService` now resolves translation service via factory to always use the currently active language.
 * Refactored palette handling
   * Extended the `Palette.Merge` method and used it to improve performance and code clarity.
   * Replaced all direct `Palette = Common.DefaultPalette` assignments with `using` blocks to ensure immediate disposal.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
+* Feature: Added `civtranslate` CLI tool to scan `*.cs` files for translation calls and update key-value translation files.
+  * Scans for `.Translate("...")`, `.TranslateFormatted("...", ...)`, and `T("...")`.
+  * Normalizes keys to uppercase while keeping values as source text.
+  * Writes `key=value` entries and escapes literal `=` as `[EQ]`.
+  * Merges with existing output files, overwrites existing values for found keys, and prints old/new value changes.
+  * Writes obsolete keys to `obsoletekeys.txt` in the output directory.
 * Refactored palette handling
   * Extended the `Palette.Merge` method and used it to improve performance and code clarity.
   * Replaced all direct `Palette = Common.DefaultPalette` assignments with `using` blocks to ensure immediate disposal.

--- a/CivOne.sln
+++ b/CivOne.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
@@ -11,6 +12,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runtime", "runtime", "{4052B028-E04B-4794-B217-98ADEF4D1D11}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CivOne.SDL", "runtime\sdl\CivOne.SDL.csproj", "{8BE1D37B-A67C-4918-A33C-BA80470DF1C9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "civtranslate", "civtranslate\civtranslate.csproj", "{534EDC2A-3F06-452D-BD96-ED44617532A7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -70,6 +73,18 @@ Global
 		{8BE1D37B-A67C-4918-A33C-BA80470DF1C9}.Release|x64.Build.0 = Release|Any CPU
 		{8BE1D37B-A67C-4918-A33C-BA80470DF1C9}.Release|x86.ActiveCfg = Release|Any CPU
 		{8BE1D37B-A67C-4918-A33C-BA80470DF1C9}.Release|x86.Build.0 = Release|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Debug|x64.Build.0 = Debug|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Debug|x86.Build.0 = Debug|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Release|x64.ActiveCfg = Release|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Release|x64.Build.0 = Release|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Release|x86.ActiveCfg = Release|Any CPU
+		{534EDC2A-3F06-452D-BD96-ED44617532A7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Open `Game Options`, then select `Language`.
 Choose `Identity (default)` to use original keys, or choose one of the available `civ_<postfix>.txt` language files.
 
 Language files must be placed in your CivOne profile translation folder.
-On Windows this is `%LOCALAPPDATA%\CivOne\translation`.
-On Linux and macOS this is `~/CivOne/translation`.
+On Windows this is `%LOCALAPPDATA%\CivOne\translations`.
+On Linux and macOS this is `~/.local/share/CivOne/translations`.
 
 To create or update language files, run the CLI scanner from repository root and copy the output file to your profile translation folder with a `civ_<postfix>.txt` name.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ There are some command line parameters that can be used to modify the behavior o
 | `--mcp-artifacts <path>` | Sets the directory where MCP screenshot artifacts are saved. Defaults to `temp/mcp-runs/` inside the storage directory. |
 | `--mcp-saves <path>` | Sets the directory where MCP save tools read and write `.cos` files (`game_list_saves`, `game_load`, `game_save`). |
 
+### Translation workflow
+
+The repository includes a small CLI tool named `civtranslate` to maintain translation key-value files from C# code.
+
+Run from the repository root:
+
+```sh
+dotnet run --project ./civtranslate/civtranslate.csproj -- ./src --output ./translation/all.txt
+```
+
+The scanner looks for `.Translate("...")`, `.TranslateFormatted("...", ...)`, and `T("...")` calls in `*.cs` files.
+Keys are normalized to uppercase for matching and output, while values keep the source text casing.
+Existing keys found during scan have their value overwritten with the latest source text.
+Obsolete keys are written to `./translation/obsoletekeys.txt`.
+
+Helper scripts are available in the repository root:
+
+* `translate.ps1`
+* `translate.sh`
+
 ### MCP savegame tools
 
 When MCP is enabled, savegame automation tools can read and write `.cos` files in the configured MCP saves folder.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,25 @@ Helper scripts are available in the repository root:
 * `translate.ps1`
 * `translate.sh`
 
+### Use translation in game
+
+Translation is now active in the game UI and gameplay text.
+You can select the language in the setup menu with `Shift + F1`.
+Open `Game Options`, then select `Language`.
+Choose `Identity (default)` to use original keys, or choose one of the available `civ_<postfix>.txt` language files.
+
+Language files must be placed in your CivOne profile translation folder.
+On Windows this is `%LOCALAPPDATA%\CivOne\translation`.
+On Linux and macOS this is `~/CivOne/translation`.
+
+To create or update language files, run the CLI scanner from repository root and copy the output file to your profile translation folder with a `civ_<postfix>.txt` name.
+
+Example:
+
+```sh
+dotnet run --project ./civtranslate/civtranslate.csproj -- ./src --output ./translation/civ_german.txt
+```
+
 ### MCP savegame tools
 
 When MCP is enabled, savegame automation tools can read and write `.cos` files in the configured MCP saves folder.
@@ -265,6 +284,7 @@ These options affect the gameplay mechanics and rules and can also be changed in
 | Civilopedia Text | Select Civilopedia text display mode (affects in-game encyclopedia text). |
 | Palace | Toggle palace-related behaviour or display options in cities. |
 | Tax Rate | Set the tax rate which splits commerce between gold and science (0%–100%). |
+| Language | Select active translation language (`Identity` or any valid `civ_<postfix>.txt` file from the profile translation folder). |
 
 
 #### Launch Game / Return to Game

--- a/civtranslate/Program.cs
+++ b/civtranslate/Program.cs
@@ -177,11 +177,17 @@ static IEnumerable<InvocationCandidate> EnumerateInvocationCandidates(string con
 			index = openParen2;
 			continue;
 		}
-
-		if (TryMatchTInvocation(content, index, out int openParen3))
+		if (TryMatchInvocation(content, index, "Translate", out int openParen3))
 		{
-			yield return new InvocationCandidate("T", openParen3);
+			yield return new InvocationCandidate("Translate", openParen3);
 			index = openParen3;
+			continue;
+		}
+
+		if (TryMatchTInvocation(content, index, out int openParen4))
+		{
+			yield return new InvocationCandidate("T", openParen4);
+			index = openParen4;
 		}
 	}
 }
@@ -604,6 +610,7 @@ static void PrintHelp()
 	Console.WriteLine();
 	Console.WriteLine("Scan patterns:");
 	Console.WriteLine("  .Translate(\"...\")");
+	Console.WriteLine("  Translate(\"...\")");
 	Console.WriteLine("  .TranslateFormatted(\"...\", ...)");
 	Console.WriteLine("  T(\"...\")");
 	Console.WriteLine();

--- a/civtranslate/Program.cs
+++ b/civtranslate/Program.cs
@@ -1,0 +1,604 @@
+using System.Text;
+
+const string DefaultOutputFileName = "translate_all.txt";
+const string DefaultObsoleteKeysFileName = "obsoletekeys.txt";
+const string EqualsPlaceholder = "[EQ]";
+
+if (args.Length == 0)
+{
+    PrintHelp();
+    return 1;
+}
+
+if (HasHelpSwitch(args))
+{
+    PrintHelp();
+    return 0;
+}
+
+if (!TryParseArguments(args, out string inputFolderArgument, out string outputPath, out string parseError))
+{
+    Console.Error.WriteLine($"Error: {parseError}");
+    Console.WriteLine();
+    PrintHelp();
+    return 2;
+}
+
+string inputFolder = Path.GetFullPath(inputFolderArgument);
+if (!Directory.Exists(inputFolder))
+{
+    Console.Error.WriteLine($"Error: Input directory not found: {inputFolder}");
+    return 2;
+}
+
+if (string.IsNullOrWhiteSpace(outputPath))
+{
+    outputPath = DefaultOutputFileName;
+}
+
+string outputFile = Path.GetFullPath(outputPath);
+string outputDirectory = Path.GetDirectoryName(outputFile) ?? Directory.GetCurrentDirectory();
+string obsoleteKeysFile = Path.Combine(outputDirectory, DefaultObsoleteKeysFileName);
+
+ScanReport scanReport = ScanDirectory(inputFolder);
+TranslationFile existingFile = ReadTranslationFileIfExists(outputFile);
+MergeReport mergeReport = Merge(scanReport, existingFile);
+WriteTranslationFile(outputFile, mergeReport);
+WriteObsoleteKeysFile(obsoleteKeysFile, mergeReport.ObsoleteEntries);
+
+PrintWarnings(scanReport, mergeReport);
+PrintSummary(scanReport, existingFile, mergeReport, outputFile, obsoleteKeysFile);
+
+return 0;
+
+static bool HasHelpSwitch(string[] args) => args.Any(x => x.Equals("--help", StringComparison.OrdinalIgnoreCase) || x.Equals("-h", StringComparison.OrdinalIgnoreCase));
+
+static bool TryParseArguments(string[] args, out string inputFolder, out string outputFile, out string error)
+{
+    inputFolder = string.Empty;
+    outputFile = DefaultOutputFileName;
+    error = string.Empty;
+
+    List<string> positionals = [];
+
+    for (int i = 0; i < args.Length; i++)
+    {
+        string arg = args[i];
+        if (arg.Equals("--output", StringComparison.OrdinalIgnoreCase))
+        {
+            if (i + 1 >= args.Length)
+            {
+                error = "--output requires a filename.";
+                return false;
+            }
+
+            outputFile = args[++i];
+            if (string.IsNullOrWhiteSpace(outputFile))
+            {
+                error = "--output value must not be empty.";
+                return false;
+            }
+
+            continue;
+        }
+
+        if (arg.StartsWith("--", StringComparison.Ordinal) && !arg.Equals("--output", StringComparison.OrdinalIgnoreCase))
+        {
+            error = $"Unknown option: {arg}";
+            return false;
+        }
+
+        if (arg.StartsWith("-", StringComparison.Ordinal) && !arg.Equals("-h", StringComparison.OrdinalIgnoreCase))
+        {
+            error = $"Unknown option: {arg}";
+            return false;
+        }
+
+        positionals.Add(arg);
+    }
+
+    if (positionals.Count != 1)
+    {
+        error = "Exactly one input directory is required.";
+        return false;
+    }
+
+    inputFolder = positionals[0];
+    return true;
+}
+
+static ScanReport ScanDirectory(string inputFolder)
+{
+    List<FoundKey> foundKeys = [];
+    Dictionary<string, FoundKey> uniqueByNormalized = new(StringComparer.OrdinalIgnoreCase);
+    List<InterpolationWarning> interpolationWarnings = [];
+
+    string[] files = Directory
+        .EnumerateFiles(inputFolder, "*.cs", SearchOption.AllDirectories)
+        .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    foreach (string file in files)
+    {
+        string content = File.ReadAllText(file, Encoding.UTF8);
+
+        foreach (InvocationCandidate candidate in EnumerateInvocationCandidates(content))
+        {
+            if (!TryExtractFirstStringArgument(content, candidate.OpenParenIndex, out ExtractedArgument extracted))
+            {
+                continue;
+            }
+
+            if (extracted.IsInterpolated)
+            {
+                interpolationWarnings.Add(new InterpolationWarning(file, extracted.Line, candidate.PatternName));
+                continue;
+            }
+
+            string normalizedKey = NormalizeKey(extracted.Text);
+            if (normalizedKey.Length == 0)
+            {
+                continue;
+            }
+
+            if (!uniqueByNormalized.ContainsKey(normalizedKey))
+            {
+                FoundKey found = new(normalizedKey, extracted.Text, file, extracted.Line);
+                uniqueByNormalized[normalizedKey] = found;
+                foundKeys.Add(found);
+            }
+        }
+    }
+
+    return new ScanReport(files.Length, foundKeys, interpolationWarnings);
+}
+
+static IEnumerable<InvocationCandidate> EnumerateInvocationCandidates(string content)
+{
+    for (int index = 0; index < content.Length; index++)
+    {
+        if (TryMatchInvocation(content, index, ".TranslateFormatted", out int openParen1))
+        {
+            yield return new InvocationCandidate(".TranslateFormatted", openParen1);
+            index = openParen1;
+            continue;
+        }
+
+        if (TryMatchInvocation(content, index, ".Translate", out int openParen2))
+        {
+            yield return new InvocationCandidate(".Translate", openParen2);
+            index = openParen2;
+            continue;
+        }
+
+        if (TryMatchTInvocation(content, index, out int openParen3))
+        {
+            yield return new InvocationCandidate("T", openParen3);
+            index = openParen3;
+        }
+    }
+}
+
+static bool TryMatchInvocation(string content, int index, string methodName, out int openParenIndex)
+{
+    openParenIndex = -1;
+
+    if (!content.AsSpan(index).StartsWith(methodName, StringComparison.Ordinal))
+    {
+        return false;
+    }
+
+    int cursor = index + methodName.Length;
+    while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
+    {
+        cursor++;
+    }
+
+    if (cursor >= content.Length || content[cursor] != '(')
+    {
+        return false;
+    }
+
+    openParenIndex = cursor;
+    return true;
+}
+
+static bool TryMatchTInvocation(string content, int index, out int openParenIndex)
+{
+    openParenIndex = -1;
+
+    if (content[index] != 'T')
+    {
+        return false;
+    }
+
+    if (index > 0)
+    {
+        char prev = content[index - 1];
+        if (char.IsLetterOrDigit(prev) || prev == '_')
+        {
+            return false;
+        }
+    }
+
+    int cursor = index + 1;
+    while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
+    {
+        cursor++;
+    }
+
+    if (cursor >= content.Length || content[cursor] != '(')
+    {
+        return false;
+    }
+
+    openParenIndex = cursor;
+    return true;
+}
+
+static bool TryExtractFirstStringArgument(string content, int openParenIndex, out ExtractedArgument argument)
+{
+    argument = default;
+
+    int cursor = openParenIndex + 1;
+    while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
+    {
+        cursor++;
+    }
+
+    bool hasDollar = false;
+    bool isVerbatim = false;
+
+    bool consumedPrefix = true;
+    while (consumedPrefix && cursor < content.Length)
+    {
+        consumedPrefix = false;
+        if (content[cursor] == '$')
+        {
+            hasDollar = true;
+            cursor++;
+            consumedPrefix = true;
+        }
+        else if (content[cursor] == '@')
+        {
+            isVerbatim = true;
+            cursor++;
+            consumedPrefix = true;
+        }
+    }
+
+    if (cursor >= content.Length || content[cursor] != '"')
+    {
+        return false;
+    }
+
+    int line = GetLineNumber(content, cursor);
+    bool success = isVerbatim
+        ? TryParseVerbatimString(content, cursor, out string text)
+        : TryParseRegularString(content, cursor, out text);
+
+    if (!success)
+    {
+        return false;
+    }
+
+    argument = new ExtractedArgument(text, hasDollar, line);
+    return true;
+}
+
+static bool TryParseRegularString(string content, int startQuoteIndex, out string text)
+{
+    text = string.Empty;
+    StringBuilder builder = new();
+
+    int cursor = startQuoteIndex + 1;
+    while (cursor < content.Length)
+    {
+        char ch = content[cursor];
+        if (ch == '"')
+        {
+            text = builder.ToString();
+            return true;
+        }
+
+        if (ch == '\\')
+        {
+            if (cursor + 1 >= content.Length)
+            {
+                return false;
+            }
+
+            char escaped = content[cursor + 1];
+            builder.Append(escaped switch
+            {
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                '"' => '"',
+                '\\' => '\\',
+                _ => escaped
+            });
+            cursor += 2;
+            continue;
+        }
+
+        builder.Append(ch);
+        cursor++;
+    }
+
+    return false;
+}
+
+static bool TryParseVerbatimString(string content, int startQuoteIndex, out string text)
+{
+    text = string.Empty;
+    StringBuilder builder = new();
+
+    int cursor = startQuoteIndex + 1;
+    while (cursor < content.Length)
+    {
+        char ch = content[cursor];
+        if (ch == '"')
+        {
+            if (cursor + 1 < content.Length && content[cursor + 1] == '"')
+            {
+                builder.Append('"');
+                cursor += 2;
+                continue;
+            }
+
+            text = builder.ToString();
+            return true;
+        }
+
+        builder.Append(ch);
+        cursor++;
+    }
+
+    return false;
+}
+
+static int GetLineNumber(string content, int position)
+{
+    int line = 1;
+    for (int i = 0; i < position && i < content.Length; i++)
+    {
+        if (content[i] == '\n')
+        {
+            line++;
+        }
+    }
+
+    return line;
+}
+
+static TranslationFile ReadTranslationFileIfExists(string outputFile)
+{
+    if (!File.Exists(outputFile))
+    {
+        return new TranslationFile([], new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+    }
+
+    List<TranslationEntry> entries = [];
+    Dictionary<string, string> byNormalized = new(StringComparer.OrdinalIgnoreCase);
+
+    string[] lines = File.ReadAllLines(outputFile, Encoding.UTF8);
+    for (int i = 0; i < lines.Length; i++)
+    {
+        string line = lines[i];
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            continue;
+        }
+
+        int separatorIndex = line.IndexOf('=');
+        if (separatorIndex < 0)
+        {
+            Console.WriteLine($"Warning: Ignoring malformed line in existing file ({outputFile}:{i + 1}): {line}");
+            continue;
+        }
+
+        string rawKey = line[..separatorIndex];
+        string rawValue = line[(separatorIndex + 1)..];
+
+        string key = UnescapeEquals(rawKey).Trim();
+        string value = UnescapeEquals(rawValue);
+
+        if (key.Length == 0)
+        {
+            continue;
+        }
+
+        string normalized = NormalizeKey(key);
+        byNormalized[normalized] = value;
+        entries.Add(new TranslationEntry(normalized, value));
+    }
+
+    return new TranslationFile(entries, byNormalized);
+}
+
+static MergeReport Merge(ScanReport scanReport, TranslationFile existingFile)
+{
+    List<TranslationEntry> finalEntries = [];
+    HashSet<string> usedKeys = new(StringComparer.OrdinalIgnoreCase);
+    List<OverwrittenEntry> overwrittenEntries = [];
+    int reused = 0;
+    int added = 0;
+
+    foreach (FoundKey found in scanReport.FoundKeys)
+    {
+        if (usedKeys.Contains(found.NormalizedKey))
+        {
+            continue;
+        }
+
+        if (existingFile.ByNormalizedKey.TryGetValue(found.NormalizedKey, out string? existingValue))
+        {
+            string newValue = found.OriginalText;
+            if (!string.Equals(existingValue, newValue, StringComparison.Ordinal))
+            {
+                overwrittenEntries.Add(new OverwrittenEntry(found.NormalizedKey, existingValue, newValue));
+            }
+            finalEntries.Add(new TranslationEntry(found.NormalizedKey, newValue));
+            reused++;
+        }
+        else
+        {
+            finalEntries.Add(new TranslationEntry(found.NormalizedKey, found.OriginalText));
+            added++;
+        }
+
+        usedKeys.Add(found.NormalizedKey);
+    }
+
+    List<TranslationEntry> obsoleteEntries = [];
+    foreach (TranslationEntry existing in existingFile.Entries)
+    {
+        if (usedKeys.Contains(existing.NormalizedKey))
+        {
+            continue;
+        }
+
+        obsoleteEntries.Add(existing);
+    }
+
+    finalEntries.AddRange(obsoleteEntries);
+
+    return new MergeReport(finalEntries, added, reused, obsoleteEntries, overwrittenEntries);
+}
+
+static void WriteTranslationFile(string outputFile, MergeReport mergeReport)
+{
+    string? directory = Path.GetDirectoryName(outputFile);
+    if (!string.IsNullOrWhiteSpace(directory))
+    {
+        Directory.CreateDirectory(directory);
+    }
+
+    string tempFile = outputFile + ".tmp";
+
+    using (StreamWriter writer = new(tempFile, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+    {
+        foreach (TranslationEntry entry in mergeReport.FinalEntries)
+        {
+            string key = EscapeEquals(entry.NormalizedKey);
+            string value = EscapeEquals(entry.Value);
+            writer.WriteLine($"{key}={value}");
+        }
+    }
+
+    if (File.Exists(outputFile))
+    {
+        File.Delete(outputFile);
+    }
+
+    File.Move(tempFile, outputFile);
+}
+
+static void WriteObsoleteKeysFile(string obsoleteKeysFile, List<TranslationEntry> obsoleteEntries)
+{
+    string? directory = Path.GetDirectoryName(obsoleteKeysFile);
+    if (!string.IsNullOrWhiteSpace(directory))
+    {
+        Directory.CreateDirectory(directory);
+    }
+
+    string tempFile = obsoleteKeysFile + ".tmp";
+
+    using (StreamWriter writer = new(tempFile, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+    {
+        foreach (TranslationEntry entry in obsoleteEntries)
+        {
+            string key = EscapeEquals(entry.NormalizedKey);
+            string value = EscapeEquals(entry.Value);
+            writer.WriteLine($"{key}={value}");
+        }
+    }
+
+    if (File.Exists(obsoleteKeysFile))
+    {
+        File.Delete(obsoleteKeysFile);
+    }
+
+    File.Move(tempFile, obsoleteKeysFile);
+}
+
+static void PrintWarnings(ScanReport scanReport, MergeReport mergeReport)
+{
+    foreach (InterpolationWarning warning in scanReport.InterpolationWarnings)
+    {
+        Console.WriteLine($"Warning: Interpolated string ignored ({warning.Pattern}) at {warning.FilePath}:{warning.Line}");
+    }
+
+    foreach (OverwrittenEntry ow in mergeReport.OverwrittenEntries)
+    {
+        Console.WriteLine($"Info: Key overwritten: {ow.NormalizedKey}");
+        Console.WriteLine($"  old: {ow.OldValue}");
+        Console.WriteLine($"  new: {ow.NewValue}");
+    }
+
+    foreach (TranslationEntry obsolete in mergeReport.ObsoleteEntries)
+    {
+        Console.WriteLine($"Warning: Key not found in current scan but kept in output: {obsolete.NormalizedKey}");
+    }
+}
+
+static void PrintSummary(ScanReport scanReport, TranslationFile existingFile, MergeReport mergeReport, string outputFile, string obsoleteKeysFile)
+{
+    Console.WriteLine();
+    Console.WriteLine("Scan complete.");
+    Console.WriteLine($"Files scanned: {scanReport.FileCount}");
+    Console.WriteLine($"Keys found: {scanReport.FoundKeys.Count}");
+    Console.WriteLine($"Interpolated keys ignored: {scanReport.InterpolationWarnings.Count}");
+    Console.WriteLine($"Existing file entries loaded: {existingFile.Entries.Count}");
+    Console.WriteLine($"Keys reused: {mergeReport.ReusedCount}");
+    Console.WriteLine($"Keys added: {mergeReport.AddedCount}");
+    Console.WriteLine($"Keys overwritten: {mergeReport.OverwrittenEntries.Count}");
+    Console.WriteLine($"Obsolete keys kept: {mergeReport.ObsoleteEntries.Count}");
+    Console.WriteLine($"Output written: {outputFile}");
+    Console.WriteLine($"Obsolete keys file: {obsoleteKeysFile}");
+}
+
+static string NormalizeKey(string key) => key.Trim().ToUpperInvariant();
+
+static string EscapeEquals(string value) => value.Replace("=", EqualsPlaceholder, StringComparison.Ordinal);
+
+static string UnescapeEquals(string value) => value.Replace(EqualsPlaceholder, "=", StringComparison.Ordinal);
+
+static void PrintHelp()
+{
+    Console.WriteLine("civtranslate");
+    Console.WriteLine("Scan C# source files for translation calls and create or update a key=value translation file.");
+    Console.WriteLine();
+    Console.WriteLine("Usage:");
+    Console.WriteLine("  civtranslate <input-folder> [--output <file>]");
+    Console.WriteLine();
+    Console.WriteLine("Options:");
+    Console.WriteLine("  --output <file>  Output file path. Default: translate_all.txt");
+    Console.WriteLine("  -h, --help       Show this help text");
+    Console.WriteLine();
+    Console.WriteLine("Scan patterns:");
+    Console.WriteLine("  .Translate(\"...\")");
+    Console.WriteLine("  .TranslateFormatted(\"...\", ...)");
+    Console.WriteLine("  T(\"...\")");
+    Console.WriteLine();
+    Console.WriteLine($"Escaping:");
+    Console.WriteLine($"  Separator is '='.");
+    Console.WriteLine($"  Any '=' in keys or values is replaced with '{EqualsPlaceholder}'.");
+    Console.WriteLine();
+    Console.WriteLine("Behavior:");
+    Console.WriteLine("  Keys are normalized to uppercase before lookup and output.");
+    Console.WriteLine("  New keys are written with value equal to key.");
+    Console.WriteLine("  Interpolated strings ($\"...\") are ignored with warnings.");
+    Console.WriteLine("  Existing keys not found in the current scan are kept and warned.");
+}
+
+readonly record struct InvocationCandidate(string PatternName, int OpenParenIndex);
+readonly record struct ExtractedArgument(string Text, bool IsInterpolated, int Line);
+readonly record struct FoundKey(string NormalizedKey, string OriginalText, string FilePath, int Line);
+readonly record struct InterpolationWarning(string FilePath, int Line, string Pattern);
+readonly record struct TranslationEntry(string NormalizedKey, string Value);
+readonly record struct ScanReport(int FileCount, List<FoundKey> FoundKeys, List<InterpolationWarning> InterpolationWarnings);
+readonly record struct TranslationFile(List<TranslationEntry> Entries, Dictionary<string, string> ByNormalizedKey);
+readonly record struct OverwrittenEntry(string NormalizedKey, string OldValue, string NewValue);
+readonly record struct MergeReport(List<TranslationEntry> FinalEntries, int AddedCount, int ReusedCount, List<TranslationEntry> ObsoleteEntries, List<OverwrittenEntry> OverwrittenEntries);

--- a/civtranslate/Program.cs
+++ b/civtranslate/Program.cs
@@ -4,36 +4,43 @@ const string DefaultOutputFileName = "translate_all.txt";
 const string DefaultObsoleteKeysFileName = "obsoletekeys.txt";
 const string EqualsPlaceholder = "[EQ]";
 
+static List<string> GetDefaultHeader() =>
+[
+	"# CivOne - General translation file",
+	"# This file is used to list all translation keys and their default English values.",
+	"# See README.md from civtranslate for instructions on how to create a translation file for a specific language."
+];
+
 if (args.Length == 0)
 {
-    PrintHelp();
-    return 1;
+	PrintHelp();
+	return 1;
 }
 
 if (HasHelpSwitch(args))
 {
-    PrintHelp();
-    return 0;
+	PrintHelp();
+	return 0;
 }
 
 if (!TryParseArguments(args, out string inputFolderArgument, out string outputPath, out string parseError))
 {
-    Console.Error.WriteLine($"Error: {parseError}");
-    Console.WriteLine();
-    PrintHelp();
-    return 2;
+	Console.Error.WriteLine($"Error: {parseError}");
+	Console.WriteLine();
+	PrintHelp();
+	return 2;
 }
 
 string inputFolder = Path.GetFullPath(inputFolderArgument);
 if (!Directory.Exists(inputFolder))
 {
-    Console.Error.WriteLine($"Error: Input directory not found: {inputFolder}");
-    return 2;
+	Console.Error.WriteLine($"Error: Input directory not found: {inputFolder}");
+	return 2;
 }
 
 if (string.IsNullOrWhiteSpace(outputPath))
 {
-    outputPath = DefaultOutputFileName;
+	outputPath = DefaultOutputFileName;
 }
 
 string outputFile = Path.GetFullPath(outputPath);
@@ -55,508 +62,526 @@ static bool HasHelpSwitch(string[] args) => args.Any(x => x.Equals("--help", Str
 
 static bool TryParseArguments(string[] args, out string inputFolder, out string outputFile, out string error)
 {
-    inputFolder = string.Empty;
-    outputFile = DefaultOutputFileName;
-    error = string.Empty;
+	inputFolder = string.Empty;
+	outputFile = DefaultOutputFileName;
+	error = string.Empty;
 
-    List<string> positionals = [];
+	List<string> positionals = [];
 
-    for (int i = 0; i < args.Length; i++)
-    {
-        string arg = args[i];
-        if (arg.Equals("--output", StringComparison.OrdinalIgnoreCase))
-        {
-            if (i + 1 >= args.Length)
-            {
-                error = "--output requires a filename.";
-                return false;
-            }
+	for (int i = 0; i < args.Length; i++)
+	{
+		string arg = args[i];
+		if (arg.Equals("--output", StringComparison.OrdinalIgnoreCase))
+		{
+			if (i + 1 >= args.Length)
+			{
+				error = "--output requires a filename.";
+				return false;
+			}
 
-            outputFile = args[++i];
-            if (string.IsNullOrWhiteSpace(outputFile))
-            {
-                error = "--output value must not be empty.";
-                return false;
-            }
+			outputFile = args[++i];
+			if (string.IsNullOrWhiteSpace(outputFile))
+			{
+				error = "--output value must not be empty.";
+				return false;
+			}
 
-            continue;
-        }
+			continue;
+		}
 
-        if (arg.StartsWith("--", StringComparison.Ordinal) && !arg.Equals("--output", StringComparison.OrdinalIgnoreCase))
-        {
-            error = $"Unknown option: {arg}";
-            return false;
-        }
+		if (arg.StartsWith("--", StringComparison.Ordinal) && !arg.Equals("--output", StringComparison.OrdinalIgnoreCase))
+		{
+			error = $"Unknown option: {arg}";
+			return false;
+		}
 
-        if (arg.StartsWith("-", StringComparison.Ordinal) && !arg.Equals("-h", StringComparison.OrdinalIgnoreCase))
-        {
-            error = $"Unknown option: {arg}";
-            return false;
-        }
+		if (arg.StartsWith("-", StringComparison.Ordinal) && !arg.Equals("-h", StringComparison.OrdinalIgnoreCase))
+		{
+			error = $"Unknown option: {arg}";
+			return false;
+		}
 
-        positionals.Add(arg);
-    }
+		positionals.Add(arg);
+	}
 
-    if (positionals.Count != 1)
-    {
-        error = "Exactly one input directory is required.";
-        return false;
-    }
+	if (positionals.Count != 1)
+	{
+		error = "Exactly one input directory is required.";
+		return false;
+	}
 
-    inputFolder = positionals[0];
-    return true;
+	inputFolder = positionals[0];
+	return true;
 }
 
 static ScanReport ScanDirectory(string inputFolder)
 {
-    List<FoundKey> foundKeys = [];
-    Dictionary<string, FoundKey> uniqueByNormalized = new(StringComparer.OrdinalIgnoreCase);
-    List<InterpolationWarning> interpolationWarnings = [];
+	List<FoundKey> foundKeys = [];
+	Dictionary<string, FoundKey> uniqueByNormalized = new(StringComparer.OrdinalIgnoreCase);
+	List<InterpolationWarning> interpolationWarnings = [];
 
-    string[] files = Directory
-        .EnumerateFiles(inputFolder, "*.cs", SearchOption.AllDirectories)
-        .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-        .ToArray();
+	string[] files = Directory
+		.EnumerateFiles(inputFolder, "*.cs", SearchOption.AllDirectories)
+		.OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+		.ToArray();
 
-    foreach (string file in files)
-    {
-        string content = File.ReadAllText(file, Encoding.UTF8);
+	foreach (string file in files)
+	{
+		string content = File.ReadAllText(file, Encoding.UTF8);
 
-        foreach (InvocationCandidate candidate in EnumerateInvocationCandidates(content))
-        {
-            if (!TryExtractFirstStringArgument(content, candidate.OpenParenIndex, out ExtractedArgument extracted))
-            {
-                continue;
-            }
+		foreach (InvocationCandidate candidate in EnumerateInvocationCandidates(content))
+		{
+			if (!TryExtractFirstStringArgument(content, candidate.OpenParenIndex, out ExtractedArgument extracted))
+			{
+				continue;
+			}
 
-            if (extracted.IsInterpolated)
-            {
-                interpolationWarnings.Add(new InterpolationWarning(file, extracted.Line, candidate.PatternName));
-                continue;
-            }
+			if (extracted.IsInterpolated)
+			{
+				interpolationWarnings.Add(new InterpolationWarning(file, extracted.Line, candidate.PatternName));
+				continue;
+			}
 
-            string normalizedKey = NormalizeKey(extracted.Text);
-            if (normalizedKey.Length == 0)
-            {
-                continue;
-            }
+			string normalizedKey = NormalizeKey(extracted.Text);
+			if (normalizedKey.Length == 0)
+			{
+				continue;
+			}
 
-            if (!uniqueByNormalized.ContainsKey(normalizedKey))
-            {
-                FoundKey found = new(normalizedKey, extracted.Text, file, extracted.Line);
-                uniqueByNormalized[normalizedKey] = found;
-                foundKeys.Add(found);
-            }
-        }
-    }
+			if (!uniqueByNormalized.ContainsKey(normalizedKey))
+			{
+				FoundKey found = new(normalizedKey, extracted.Text, file, extracted.Line);
+				uniqueByNormalized[normalizedKey] = found;
+				foundKeys.Add(found);
+			}
+		}
+	}
 
-    return new ScanReport(files.Length, foundKeys, interpolationWarnings);
+	return new ScanReport(files.Length, foundKeys, interpolationWarnings);
 }
 
 static IEnumerable<InvocationCandidate> EnumerateInvocationCandidates(string content)
 {
-    for (int index = 0; index < content.Length; index++)
-    {
-        if (TryMatchInvocation(content, index, ".TranslateFormatted", out int openParen1))
-        {
-            yield return new InvocationCandidate(".TranslateFormatted", openParen1);
-            index = openParen1;
-            continue;
-        }
+	for (int index = 0; index < content.Length; index++)
+	{
+		if (TryMatchInvocation(content, index, ".TranslateFormatted", out int openParen1))
+		{
+			yield return new InvocationCandidate(".TranslateFormatted", openParen1);
+			index = openParen1;
+			continue;
+		}
 
-        if (TryMatchInvocation(content, index, ".Translate", out int openParen2))
-        {
-            yield return new InvocationCandidate(".Translate", openParen2);
-            index = openParen2;
-            continue;
-        }
+		if (TryMatchInvocation(content, index, ".Translate", out int openParen2))
+		{
+			yield return new InvocationCandidate(".Translate", openParen2);
+			index = openParen2;
+			continue;
+		}
 
-        if (TryMatchTInvocation(content, index, out int openParen3))
-        {
-            yield return new InvocationCandidate("T", openParen3);
-            index = openParen3;
-        }
-    }
+		if (TryMatchTInvocation(content, index, out int openParen3))
+		{
+			yield return new InvocationCandidate("T", openParen3);
+			index = openParen3;
+		}
+	}
 }
 
 static bool TryMatchInvocation(string content, int index, string methodName, out int openParenIndex)
 {
-    openParenIndex = -1;
+	openParenIndex = -1;
 
-    if (!content.AsSpan(index).StartsWith(methodName, StringComparison.Ordinal))
-    {
-        return false;
-    }
+	if (!content.AsSpan(index).StartsWith(methodName, StringComparison.Ordinal))
+	{
+		return false;
+	}
 
-    int cursor = index + methodName.Length;
-    while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
-    {
-        cursor++;
-    }
+	int cursor = index + methodName.Length;
+	while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
+	{
+		cursor++;
+	}
 
-    if (cursor >= content.Length || content[cursor] != '(')
-    {
-        return false;
-    }
+	if (cursor >= content.Length || content[cursor] != '(')
+	{
+		return false;
+	}
 
-    openParenIndex = cursor;
-    return true;
+	openParenIndex = cursor;
+	return true;
 }
 
 static bool TryMatchTInvocation(string content, int index, out int openParenIndex)
 {
-    openParenIndex = -1;
+	openParenIndex = -1;
 
-    if (content[index] != 'T')
-    {
-        return false;
-    }
+	if (content[index] != 'T')
+	{
+		return false;
+	}
 
-    if (index > 0)
-    {
-        char prev = content[index - 1];
-        if (char.IsLetterOrDigit(prev) || prev == '_')
-        {
-            return false;
-        }
-    }
+	if (index > 0)
+	{
+		char prev = content[index - 1];
+		if (char.IsLetterOrDigit(prev) || prev == '_')
+		{
+			return false;
+		}
+	}
 
-    int cursor = index + 1;
-    while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
-    {
-        cursor++;
-    }
+	int cursor = index + 1;
+	while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
+	{
+		cursor++;
+	}
 
-    if (cursor >= content.Length || content[cursor] != '(')
-    {
-        return false;
-    }
+	if (cursor >= content.Length || content[cursor] != '(')
+	{
+		return false;
+	}
 
-    openParenIndex = cursor;
-    return true;
+	openParenIndex = cursor;
+	return true;
 }
 
 static bool TryExtractFirstStringArgument(string content, int openParenIndex, out ExtractedArgument argument)
 {
-    argument = default;
+	argument = default;
 
-    int cursor = openParenIndex + 1;
-    while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
-    {
-        cursor++;
-    }
+	int cursor = openParenIndex + 1;
+	while (cursor < content.Length && char.IsWhiteSpace(content[cursor]))
+	{
+		cursor++;
+	}
 
-    bool hasDollar = false;
-    bool isVerbatim = false;
+	bool hasDollar = false;
+	bool isVerbatim = false;
 
-    bool consumedPrefix = true;
-    while (consumedPrefix && cursor < content.Length)
-    {
-        consumedPrefix = false;
-        if (content[cursor] == '$')
-        {
-            hasDollar = true;
-            cursor++;
-            consumedPrefix = true;
-        }
-        else if (content[cursor] == '@')
-        {
-            isVerbatim = true;
-            cursor++;
-            consumedPrefix = true;
-        }
-    }
+	bool consumedPrefix = true;
+	while (consumedPrefix && cursor < content.Length)
+	{
+		consumedPrefix = false;
+		if (content[cursor] == '$')
+		{
+			hasDollar = true;
+			cursor++;
+			consumedPrefix = true;
+		}
+		else if (content[cursor] == '@')
+		{
+			isVerbatim = true;
+			cursor++;
+			consumedPrefix = true;
+		}
+	}
 
-    if (cursor >= content.Length || content[cursor] != '"')
-    {
-        return false;
-    }
+	if (cursor >= content.Length || content[cursor] != '"')
+	{
+		return false;
+	}
 
-    int line = GetLineNumber(content, cursor);
-    bool success = isVerbatim
-        ? TryParseVerbatimString(content, cursor, out string text)
-        : TryParseRegularString(content, cursor, out text);
+	int line = GetLineNumber(content, cursor);
+	bool success = isVerbatim
+		? TryParseVerbatimString(content, cursor, out string text)
+		: TryParseRegularString(content, cursor, out text);
 
-    if (!success)
-    {
-        return false;
-    }
+	if (!success)
+	{
+		return false;
+	}
 
-    argument = new ExtractedArgument(text, hasDollar, line);
-    return true;
+	argument = new ExtractedArgument(text, hasDollar, line);
+	return true;
 }
 
 static bool TryParseRegularString(string content, int startQuoteIndex, out string text)
 {
-    text = string.Empty;
-    StringBuilder builder = new();
+	text = string.Empty;
+	StringBuilder builder = new();
 
-    int cursor = startQuoteIndex + 1;
-    while (cursor < content.Length)
-    {
-        char ch = content[cursor];
-        if (ch == '"')
-        {
-            text = builder.ToString();
-            return true;
-        }
+	int cursor = startQuoteIndex + 1;
+	while (cursor < content.Length)
+	{
+		char ch = content[cursor];
+		if (ch == '"')
+		{
+			text = builder.ToString();
+			return true;
+		}
 
-        if (ch == '\\')
-        {
-            if (cursor + 1 >= content.Length)
-            {
-                return false;
-            }
+		if (ch == '\\')
+		{
+			if (cursor + 1 >= content.Length)
+			{
+				return false;
+			}
 
-            char escaped = content[cursor + 1];
-            builder.Append(escaped switch
-            {
-                'n' => '\n',
-                'r' => '\r',
-                't' => '\t',
-                '"' => '"',
-                '\\' => '\\',
-                _ => escaped
-            });
-            cursor += 2;
-            continue;
-        }
+			char escaped = content[cursor + 1];
+			builder.Append(escaped switch
+			{
+				'n' => '\n',
+				'r' => '\r',
+				't' => '\t',
+				'"' => '"',
+				'\\' => '\\',
+				_ => escaped
+			});
+			cursor += 2;
+			continue;
+		}
 
-        builder.Append(ch);
-        cursor++;
-    }
+		builder.Append(ch);
+		cursor++;
+	}
 
-    return false;
+	return false;
 }
 
 static bool TryParseVerbatimString(string content, int startQuoteIndex, out string text)
 {
-    text = string.Empty;
-    StringBuilder builder = new();
+	text = string.Empty;
+	StringBuilder builder = new();
 
-    int cursor = startQuoteIndex + 1;
-    while (cursor < content.Length)
-    {
-        char ch = content[cursor];
-        if (ch == '"')
-        {
-            if (cursor + 1 < content.Length && content[cursor + 1] == '"')
-            {
-                builder.Append('"');
-                cursor += 2;
-                continue;
-            }
+	int cursor = startQuoteIndex + 1;
+	while (cursor < content.Length)
+	{
+		char ch = content[cursor];
+		if (ch == '"')
+		{
+			if (cursor + 1 < content.Length && content[cursor + 1] == '"')
+			{
+				builder.Append('"');
+				cursor += 2;
+				continue;
+			}
 
-            text = builder.ToString();
-            return true;
-        }
+			text = builder.ToString();
+			return true;
+		}
 
-        builder.Append(ch);
-        cursor++;
-    }
+		builder.Append(ch);
+		cursor++;
+	}
 
-    return false;
+	return false;
 }
 
 static int GetLineNumber(string content, int position)
 {
-    int line = 1;
-    for (int i = 0; i < position && i < content.Length; i++)
-    {
-        if (content[i] == '\n')
-        {
-            line++;
-        }
-    }
+	int line = 1;
+	for (int i = 0; i < position && i < content.Length; i++)
+	{
+		if (content[i] == '\n')
+		{
+			line++;
+		}
+	}
 
-    return line;
+	return line;
 }
 
 static TranslationFile ReadTranslationFileIfExists(string outputFile)
 {
-    if (!File.Exists(outputFile))
-    {
-        return new TranslationFile([], new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
-    }
+	if (!File.Exists(outputFile))
+	{
+		return new TranslationFile([], new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase), []);
+	}
 
-    List<TranslationEntry> entries = [];
-    Dictionary<string, string> byNormalized = new(StringComparer.OrdinalIgnoreCase);
+	List<TranslationEntry> entries = [];
+	Dictionary<string, string> byNormalized = new(StringComparer.OrdinalIgnoreCase);
+	List<string> comments = [];
 
-    string[] lines = File.ReadAllLines(outputFile, Encoding.UTF8);
-    for (int i = 0; i < lines.Length; i++)
-    {
-        string line = lines[i];
-        if (string.IsNullOrWhiteSpace(line))
-        {
-            continue;
-        }
+	string[] lines = File.ReadAllLines(outputFile, Encoding.UTF8);
+	for (int i = 0; i < lines.Length; i++)
+	{
+		string line = lines[i];
+		if (string.IsNullOrWhiteSpace(line))
+		{
+			continue;
+		}
 
-        int separatorIndex = line.IndexOf('=');
-        if (separatorIndex < 0)
-        {
-            Console.WriteLine($"Warning: Ignoring malformed line in existing file ({outputFile}:{i + 1}): {line}");
-            continue;
-        }
+		if (line.StartsWith("#"))
+		{
+			comments.Add(line);
+			continue;
+		}
 
-        string rawKey = line[..separatorIndex];
-        string rawValue = line[(separatorIndex + 1)..];
+		int separatorIndex = line.IndexOf('=');
+		if (separatorIndex < 0)
+		{
+			Console.WriteLine($"Warning: Ignoring malformed line in existing file ({outputFile}:{i + 1}): {line}");
+			continue;
+		}
 
-        string key = UnescapeEquals(rawKey).Trim();
-        string value = UnescapeEquals(rawValue);
+		string rawKey = line[..separatorIndex];
+		string rawValue = line[(separatorIndex + 1)..];
 
-        if (key.Length == 0)
-        {
-            continue;
-        }
+		string key = UnescapeEquals(rawKey).Trim();
+		string value = UnescapeEquals(rawValue);
 
-        string normalized = NormalizeKey(key);
-        byNormalized[normalized] = value;
-        entries.Add(new TranslationEntry(normalized, value));
-    }
+		if (key.Length == 0)
+		{
+			continue;
+		}
 
-    return new TranslationFile(entries, byNormalized);
+		string normalized = NormalizeKey(key);
+		byNormalized[normalized] = value;
+		entries.Add(new TranslationEntry(normalized, value));
+	}
+
+	return new TranslationFile(entries, byNormalized, comments);
 }
 
 static MergeReport Merge(ScanReport scanReport, TranslationFile existingFile)
 {
-    List<TranslationEntry> finalEntries = [];
-    HashSet<string> usedKeys = new(StringComparer.OrdinalIgnoreCase);
-    List<OverwrittenEntry> overwrittenEntries = [];
-    int reused = 0;
-    int added = 0;
+	List<TranslationEntry> finalEntries = [];
+	HashSet<string> usedKeys = new(StringComparer.OrdinalIgnoreCase);
+	List<OverwrittenEntry> overwrittenEntries = [];
+	int reused = 0;
+	int added = 0;
+	List<string> comments = existingFile.Comments.Count > 0 ? existingFile.Comments : GetDefaultHeader();
 
-    foreach (FoundKey found in scanReport.FoundKeys)
-    {
-        if (usedKeys.Contains(found.NormalizedKey))
-        {
-            continue;
-        }
+	foreach (FoundKey found in scanReport.FoundKeys)
+	{
+		if (usedKeys.Contains(found.NormalizedKey))
+		{
+			continue;
+		}
 
-        if (existingFile.ByNormalizedKey.TryGetValue(found.NormalizedKey, out string? existingValue))
-        {
-            string newValue = found.OriginalText;
-            if (!string.Equals(existingValue, newValue, StringComparison.Ordinal))
-            {
-                overwrittenEntries.Add(new OverwrittenEntry(found.NormalizedKey, existingValue, newValue));
-            }
-            finalEntries.Add(new TranslationEntry(found.NormalizedKey, newValue));
-            reused++;
-        }
-        else
-        {
-            finalEntries.Add(new TranslationEntry(found.NormalizedKey, found.OriginalText));
-            added++;
-        }
+		if (existingFile.ByNormalizedKey.TryGetValue(found.NormalizedKey, out string? existingValue))
+		{
+			string newValue = found.OriginalText;
+			if (!string.Equals(existingValue, newValue, StringComparison.Ordinal))
+			{
+				overwrittenEntries.Add(new OverwrittenEntry(found.NormalizedKey, existingValue, newValue));
+			}
+			finalEntries.Add(new TranslationEntry(found.NormalizedKey, newValue));
+			reused++;
+		}
+		else
+		{
+			finalEntries.Add(new TranslationEntry(found.NormalizedKey, found.OriginalText));
+			added++;
+		}
 
-        usedKeys.Add(found.NormalizedKey);
-    }
+		usedKeys.Add(found.NormalizedKey);
+	}
 
-    List<TranslationEntry> obsoleteEntries = [];
-    foreach (TranslationEntry existing in existingFile.Entries)
-    {
-        if (usedKeys.Contains(existing.NormalizedKey))
-        {
-            continue;
-        }
+	List<TranslationEntry> obsoleteEntries = [];
+	foreach (TranslationEntry existing in existingFile.Entries)
+	{
+		if (usedKeys.Contains(existing.NormalizedKey))
+		{
+			continue;
+		}
 
-        obsoleteEntries.Add(existing);
-    }
+		obsoleteEntries.Add(existing);
+	}
 
-    finalEntries.AddRange(obsoleteEntries);
+	finalEntries.AddRange(obsoleteEntries);
 
-    return new MergeReport(finalEntries, added, reused, obsoleteEntries, overwrittenEntries);
+	return new MergeReport(finalEntries, added, reused, obsoleteEntries, overwrittenEntries, comments);
 }
 
 static void WriteTranslationFile(string outputFile, MergeReport mergeReport)
 {
-    string? directory = Path.GetDirectoryName(outputFile);
-    if (!string.IsNullOrWhiteSpace(directory))
-    {
-        Directory.CreateDirectory(directory);
-    }
+	string? directory = Path.GetDirectoryName(outputFile);
+	if (!string.IsNullOrWhiteSpace(directory))
+	{
+		Directory.CreateDirectory(directory);
+	}
 
-    string tempFile = outputFile + ".tmp";
+	string tempFile = outputFile + ".tmp";
 
-    using (StreamWriter writer = new(tempFile, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
-    {
-        foreach (TranslationEntry entry in mergeReport.FinalEntries)
-        {
-            string key = EscapeEquals(entry.NormalizedKey);
-            string value = EscapeEquals(entry.Value);
-            writer.WriteLine($"{key}={value}");
-        }
-    }
+	using (StreamWriter writer = new(tempFile, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+	{
+		foreach (string comment in mergeReport.Comments)
+		{
+			writer.WriteLine(comment);
+		}
 
-    if (File.Exists(outputFile))
-    {
-        File.Delete(outputFile);
-    }
+		if (mergeReport.Comments.Count > 0)
+		{
+			writer.WriteLine();
+		}
 
-    File.Move(tempFile, outputFile);
+		foreach (TranslationEntry entry in mergeReport.FinalEntries)
+		{
+			string key = EscapeEquals(entry.NormalizedKey);
+			string value = EscapeEquals(entry.Value);
+			writer.WriteLine($"{key}={value}");
+		}
+	}
+
+	if (File.Exists(outputFile))
+	{
+		File.Delete(outputFile);
+	}
+
+	File.Move(tempFile, outputFile);
 }
 
 static void WriteObsoleteKeysFile(string obsoleteKeysFile, List<TranslationEntry> obsoleteEntries)
 {
-    string? directory = Path.GetDirectoryName(obsoleteKeysFile);
-    if (!string.IsNullOrWhiteSpace(directory))
-    {
-        Directory.CreateDirectory(directory);
-    }
+	string? directory = Path.GetDirectoryName(obsoleteKeysFile);
+	if (!string.IsNullOrWhiteSpace(directory))
+	{
+		Directory.CreateDirectory(directory);
+	}
 
-    string tempFile = obsoleteKeysFile + ".tmp";
+	string tempFile = obsoleteKeysFile + ".tmp";
 
-    using (StreamWriter writer = new(tempFile, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
-    {
-        foreach (TranslationEntry entry in obsoleteEntries)
-        {
-            string key = EscapeEquals(entry.NormalizedKey);
-            string value = EscapeEquals(entry.Value);
-            writer.WriteLine($"{key}={value}");
-        }
-    }
+	using (StreamWriter writer = new(tempFile, false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+	{
+		foreach (TranslationEntry entry in obsoleteEntries)
+		{
+			string key = EscapeEquals(entry.NormalizedKey);
+			string value = EscapeEquals(entry.Value);
+			writer.WriteLine($"{key}={value}");
+		}
+	}
 
-    if (File.Exists(obsoleteKeysFile))
-    {
-        File.Delete(obsoleteKeysFile);
-    }
+	if (File.Exists(obsoleteKeysFile))
+	{
+		File.Delete(obsoleteKeysFile);
+	}
 
-    File.Move(tempFile, obsoleteKeysFile);
+	File.Move(tempFile, obsoleteKeysFile);
 }
 
 static void PrintWarnings(ScanReport scanReport, MergeReport mergeReport)
 {
-    foreach (InterpolationWarning warning in scanReport.InterpolationWarnings)
-    {
-        Console.WriteLine($"Warning: Interpolated string ignored ({warning.Pattern}) at {warning.FilePath}:{warning.Line}");
-    }
+	foreach (InterpolationWarning warning in scanReport.InterpolationWarnings)
+	{
+		Console.WriteLine($"Warning: Interpolated string ignored ({warning.Pattern}) at {warning.FilePath}:{warning.Line}");
+	}
 
-    foreach (OverwrittenEntry ow in mergeReport.OverwrittenEntries)
-    {
-        Console.WriteLine($"Info: Key overwritten: {ow.NormalizedKey}");
-        Console.WriteLine($"  old: {ow.OldValue}");
-        Console.WriteLine($"  new: {ow.NewValue}");
-    }
+	foreach (OverwrittenEntry ow in mergeReport.OverwrittenEntries)
+	{
+		Console.WriteLine($"Info: Key overwritten: {ow.NormalizedKey}");
+		Console.WriteLine($"  old: {ow.OldValue}");
+		Console.WriteLine($"  new: {ow.NewValue}");
+	}
 
-    foreach (TranslationEntry obsolete in mergeReport.ObsoleteEntries)
-    {
-        Console.WriteLine($"Warning: Key not found in current scan but kept in output: {obsolete.NormalizedKey}");
-    }
+	foreach (TranslationEntry obsolete in mergeReport.ObsoleteEntries)
+	{
+		Console.WriteLine($"Warning: Key not found in current scan but kept in output: {obsolete.NormalizedKey}");
+	}
 }
 
 static void PrintSummary(ScanReport scanReport, TranslationFile existingFile, MergeReport mergeReport, string outputFile, string obsoleteKeysFile)
 {
-    Console.WriteLine();
-    Console.WriteLine("Scan complete.");
-    Console.WriteLine($"Files scanned: {scanReport.FileCount}");
-    Console.WriteLine($"Keys found: {scanReport.FoundKeys.Count}");
-    Console.WriteLine($"Interpolated keys ignored: {scanReport.InterpolationWarnings.Count}");
-    Console.WriteLine($"Existing file entries loaded: {existingFile.Entries.Count}");
-    Console.WriteLine($"Keys reused: {mergeReport.ReusedCount}");
-    Console.WriteLine($"Keys added: {mergeReport.AddedCount}");
-    Console.WriteLine($"Keys overwritten: {mergeReport.OverwrittenEntries.Count}");
-    Console.WriteLine($"Obsolete keys kept: {mergeReport.ObsoleteEntries.Count}");
-    Console.WriteLine($"Output written: {outputFile}");
-    Console.WriteLine($"Obsolete keys file: {obsoleteKeysFile}");
+	Console.WriteLine();
+	Console.WriteLine("Scan complete.");
+	Console.WriteLine($"Files scanned: {scanReport.FileCount}");
+	Console.WriteLine($"Keys found: {scanReport.FoundKeys.Count}");
+	Console.WriteLine($"Interpolated keys ignored: {scanReport.InterpolationWarnings.Count}");
+	Console.WriteLine($"Existing file entries loaded: {existingFile.Entries.Count}");
+	Console.WriteLine($"Keys reused: {mergeReport.ReusedCount}");
+	Console.WriteLine($"Keys added: {mergeReport.AddedCount}");
+	Console.WriteLine($"Keys overwritten: {mergeReport.OverwrittenEntries.Count}");
+	Console.WriteLine($"Obsolete keys kept: {mergeReport.ObsoleteEntries.Count}");
+	Console.WriteLine($"Output written: {outputFile}");
+	Console.WriteLine($"Obsolete keys file: {obsoleteKeysFile}");
 }
 
 static string NormalizeKey(string key) => key.Trim().ToUpperInvariant();
@@ -567,38 +592,38 @@ static string UnescapeEquals(string value) => value.Replace(EqualsPlaceholder, "
 
 static void PrintHelp()
 {
-    Console.WriteLine("civtranslate");
-    Console.WriteLine("Scan C# source files for translation calls and create or update a key=value translation file.");
-    Console.WriteLine();
-    Console.WriteLine("Usage:");
-    Console.WriteLine("  civtranslate <input-folder> [--output <file>]");
-    Console.WriteLine();
-    Console.WriteLine("Options:");
-    Console.WriteLine("  --output <file>  Output file path. Default: translate_all.txt");
-    Console.WriteLine("  -h, --help       Show this help text");
-    Console.WriteLine();
-    Console.WriteLine("Scan patterns:");
-    Console.WriteLine("  .Translate(\"...\")");
-    Console.WriteLine("  .TranslateFormatted(\"...\", ...)");
-    Console.WriteLine("  T(\"...\")");
-    Console.WriteLine();
-    Console.WriteLine($"Escaping:");
-    Console.WriteLine($"  Separator is '='.");
-    Console.WriteLine($"  Any '=' in keys or values is replaced with '{EqualsPlaceholder}'.");
-    Console.WriteLine();
-    Console.WriteLine("Behavior:");
-    Console.WriteLine("  Keys are normalized to uppercase before lookup and output.");
-    Console.WriteLine("  New keys are written with value equal to key.");
-    Console.WriteLine("  Interpolated strings ($\"...\") are ignored with warnings.");
-    Console.WriteLine("  Existing keys not found in the current scan are kept and warned.");
+	Console.WriteLine("civtranslate");
+	Console.WriteLine("Scan C# source files for translation calls and create or update a key=value translation file.");
+	Console.WriteLine();
+	Console.WriteLine("Usage:");
+	Console.WriteLine("  civtranslate <input-folder> [--output <file>]");
+	Console.WriteLine();
+	Console.WriteLine("Options:");
+	Console.WriteLine("  --output <file>  Output file path. Default: translate_all.txt");
+	Console.WriteLine("  -h, --help       Show this help text");
+	Console.WriteLine();
+	Console.WriteLine("Scan patterns:");
+	Console.WriteLine("  .Translate(\"...\")");
+	Console.WriteLine("  .TranslateFormatted(\"...\", ...)");
+	Console.WriteLine("  T(\"...\")");
+	Console.WriteLine();
+	Console.WriteLine($"Escaping:");
+	Console.WriteLine($"  Separator is '='.");
+	Console.WriteLine($"  Any '=' in keys or values is replaced with '{EqualsPlaceholder}'.");
+	Console.WriteLine();
+	Console.WriteLine("Behavior:");
+	Console.WriteLine("  Keys are normalized to uppercase before lookup and output.");
+	Console.WriteLine("  New keys are written with value equal to key.");
+	Console.WriteLine("  Interpolated strings ($\"...\") are ignored with warnings.");
+	Console.WriteLine("  Existing keys not found in the current scan are kept and warned.");
 }
 
-readonly record struct InvocationCandidate(string PatternName, int OpenParenIndex);
-readonly record struct ExtractedArgument(string Text, bool IsInterpolated, int Line);
-readonly record struct FoundKey(string NormalizedKey, string OriginalText, string FilePath, int Line);
-readonly record struct InterpolationWarning(string FilePath, int Line, string Pattern);
-readonly record struct TranslationEntry(string NormalizedKey, string Value);
-readonly record struct ScanReport(int FileCount, List<FoundKey> FoundKeys, List<InterpolationWarning> InterpolationWarnings);
-readonly record struct TranslationFile(List<TranslationEntry> Entries, Dictionary<string, string> ByNormalizedKey);
-readonly record struct OverwrittenEntry(string NormalizedKey, string OldValue, string NewValue);
-readonly record struct MergeReport(List<TranslationEntry> FinalEntries, int AddedCount, int ReusedCount, List<TranslationEntry> ObsoleteEntries, List<OverwrittenEntry> OverwrittenEntries);
+internal readonly record struct InvocationCandidate(string PatternName, int OpenParenIndex);
+internal readonly record struct ExtractedArgument(string Text, bool IsInterpolated, int Line);
+internal readonly record struct FoundKey(string NormalizedKey, string OriginalText, string FilePath, int Line);
+internal readonly record struct InterpolationWarning(string FilePath, int Line, string Pattern);
+internal readonly record struct TranslationEntry(string NormalizedKey, string Value);
+internal readonly record struct ScanReport(int FileCount, List<FoundKey> FoundKeys, List<InterpolationWarning> InterpolationWarnings);
+internal readonly record struct TranslationFile(List<TranslationEntry> Entries, Dictionary<string, string> ByNormalizedKey, List<string> Comments);
+internal readonly record struct OverwrittenEntry(string NormalizedKey, string OldValue, string NewValue);
+internal readonly record struct MergeReport(List<TranslationEntry> FinalEntries, int AddedCount, int ReusedCount, List<TranslationEntry> ObsoleteEntries, List<OverwrittenEntry> OverwrittenEntries, List<string> Comments);

--- a/civtranslate/README.md
+++ b/civtranslate/README.md
@@ -30,7 +30,7 @@ Rules:
 
 - Key matching is case-insensitive by normalizing keys to uppercase.
 - Output keys are always uppercase.
-- If a key is new, value is set to the same uppercase key.
+- If a key is new, value is set to the original source text.
 
 Separator escape rule:
 
@@ -43,7 +43,7 @@ If the output file already exists:
 
 - Existing entries are loaded into a dictionary by uppercase key.
 - Found keys reuse existing values.
-- New keys are added.
+- New keys are added with the original source text as the value.
 - Keys not found in current scan are kept.
 - A warning is printed for each kept key that is no longer found.
 

--- a/civtranslate/README.md
+++ b/civtranslate/README.md
@@ -1,0 +1,73 @@
+# civtranslate
+
+civtranslate is a small C# CLI tool for CivOne.
+It scans C# files for translation calls and creates or updates a key-value translation file.
+
+## What it scans
+
+The scanner searches `*.cs` files in a folder recursively.
+It extracts keys from these call patterns:
+
+- `.Translate("...")`
+- `.TranslateFormatted("...", ...)`
+- `T("...")`
+
+It supports multiple matches in one line.
+
+## Interpolation behavior
+
+Interpolated strings are ignored on purpose.
+This includes patterns like `$"..."`, `@$"..."`, and `$@"..."`.
+The tool prints a warning with file path and line number and continues scanning.
+
+Placeholders like `{0}` inside normal string literals are allowed.
+
+## Output format
+
+Output uses `key=value` lines.
+
+Rules:
+
+- Key matching is case-insensitive by normalizing keys to uppercase.
+- Output keys are always uppercase.
+- If a key is new, value is set to the same uppercase key.
+
+Separator escape rule:
+
+- Separator is `=`.
+- If `=` appears inside key or value, it is replaced with `[EQ]`.
+
+## Existing output file behavior
+
+If the output file already exists:
+
+- Existing entries are loaded into a dictionary by uppercase key.
+- Found keys reuse existing values.
+- New keys are added.
+- Keys not found in current scan are kept.
+- A warning is printed for each kept key that is no longer found.
+
+## Usage
+
+Run from repository root or any working directory.
+
+```sh
+# Show help
+ dotnet run --project ./civtranslate/civtranslate.csproj -- --help
+```
+
+```sh
+# Scan ./src and write default output translate_all.txt
+ dotnet run --project ./civtranslate/civtranslate.csproj -- ./src
+```
+
+```sh
+# Scan ./src and write custom output file
+ dotnet run --project ./civtranslate/civtranslate.csproj -- ./src --output ./translate_de.txt
+```
+
+## Build
+
+```sh
+dotnet build ./civtranslate/civtranslate.csproj
+```

--- a/civtranslate/README.md
+++ b/civtranslate/README.md
@@ -71,3 +71,37 @@ Run from repository root or any working directory.
 ```sh
 dotnet build ./civtranslate/civtranslate.csproj
 ```
+
+## Example output
+
+```
+Keys reused: 14
+Keys added: 0
+Keys overwritten: 0
+Obsolete keys kept: 1
+Output written: C:\Users\Christian\Documents\Projekte\CivOne-Chris\translation\all.txt
+PS C:\Users\Christian\Documents\Projekte\CivOne-Chris> .\translate.ps1
+Warning: Key not found in current scan but kept in output: FAST SAVE1 IS NOT AVAILABLE RIGHT NOW.
+
+Warning: Key not found in current scan but kept in output: FAST SAVE1 IS NOT AVAILABLE RIGHT NOW.
+```
+
+## Example all.txt
+
+```txt
+BC=BC
+AD=AD
+FAST SAVE IS NOT AVAILABLE RIGHT NOW.=Fast save is not available right now.
+COULD NOT SAVE FAST SAVE SLOT.=Could not save fast save slot.
+FAST SAVE SLOT IS EMPTY.=Fast save slot is empty.
+COULD NOT LOAD FAST SAVE SLOT.=Could not load fast save slot.
+QUICK SAVE/LOAD=Quick Save/Load
+IN {3} LEADER {0} {1} OF THE {2}=In {3} leader {0} {1} of the {2}
+LORD=Lord
+PRINCE=Prince
+KING=King
+EMPEROR=Emperor
+DEITY=Deity
+CHIEF=Chief
+FAST SAVE1 IS NOT AVAILABLE RIGHT NOW.=Fast save1 is not available right now.
+```

--- a/civtranslate/civtranslate.csproj
+++ b/civtranslate/civtranslate.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>13.0</LangVersion>
+    <AssemblyName>civtranslate</AssemblyName>
+    <RootNamespace>civtranslate</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -19,7 +19,7 @@ protected string TranslateFormatted(string key, params object[] args)
 
 > At this time, these are simple pass-throughs to `Translation.Translate()` and `Translation.TranslateFormatted()`. In the future, they could be extended to support context-aware translation, caching, or other features without changing the call sites.
 
-Both delegate to `ITranslationService` (created via `TranslationServiceFactory.Current()`).
+Both delegate to `ITranslationService` (created via `TranslationServiceFactory.GetCurrent()`).
 
 ---
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -19,7 +19,7 @@ protected string TranslateFormatted(string key, params object[] args)
 
 > At this time, these are simple pass-throughs to `Translation.Translate()` and `Translation.TranslateFormatted()`. In the future, they could be extended to support context-aware translation, caching, or other features without changing the call sites.
 
-Both delegate to `ITranslationService` (created via `TranslationServiceFactory.CreateDefault()`).
+Both delegate to `ITranslationService` (created via `TranslationServiceFactory.Current()`).
 
 ---
 

--- a/runtime/sdl/Resources/HelpText.txt
+++ b/runtime/sdl/Resources/HelpText.txt
@@ -13,6 +13,8 @@ runtime-options:
   --no-data-check       Disables checking for game data files
   --no-sound            Disable ingame sounds
   --profile <name>      Start CivOne using the profile specified
+  --language <postfix>  Load translation file civ_<postfix>.txt from
+                        %LocalAppData%/CivOne/translations or ~/.civone/translations
   --skip-credits        Skips the game credits sequence
   --skip-intro          Skips the game intro sequence
   --software-render     Force the use of SDL software rendererer

--- a/runtime/sdl/Resources/HelpText.txt
+++ b/runtime/sdl/Resources/HelpText.txt
@@ -14,7 +14,7 @@ runtime-options:
   --no-sound            Disable ingame sounds
   --profile <name>      Start CivOne using the profile specified
   --language <postfix>  Load translation file civ_<postfix>.txt from
-                        %LocalAppData%/CivOne/translations or ~/.civone/translations
+                        %LocalAppData%/CivOne/translations or ~/.local/share/CivOne/translations
   --skip-credits        Skips the game credits sequence
   --skip-intro          Skips the game intro sequence
   --software-render     Force the use of SDL software rendererer

--- a/runtime/sdl/src/Program.cs
+++ b/runtime/sdl/src/Program.cs
@@ -177,6 +177,22 @@ Try 'civone-sdl --help' for more information.
 						settings["profile-name"] = args[++i];
 						Console.WriteLine($@"Using profile ""{settings["profile-name"]}""");
 						break;
+					case "language":
+						if (args.GetUpperBound(0) == i)
+						{
+							Console.WriteLine("Missing language postfix argument");
+							return;
+						}
+
+						string languagePostfix = args[++i];
+						if (string.IsNullOrEmpty(languagePostfix))
+						{
+							Console.WriteLine("Invalid language postfix.");
+							return;
+						}
+
+						settings.LanguagePostfix = languagePostfix;
+						break;
 					case "load-slot":
 						// --load-slot [a-z1..10] (default no options defaults to null)
 						// optional argument is a drive letter (a-z) and a slot number (1-10)

--- a/src/BaseInstance.cs
+++ b/src/BaseInstance.cs
@@ -25,7 +25,7 @@ namespace CivOne
 		protected static Settings Settings => Settings.Instance;
 		protected static MenuCollection Menus => MenuCollection.Instance;
 
-		protected ITranslationService Translation => TranslationServiceFactory.CreateDefault();
+		protected ITranslationService Translation => TranslationServiceFactory.GetCurrent();
 
 		protected internal static void Log(string text, params object[] parameters) => Runtime.Log(text, parameters);
 		protected static void PlaySound(string filename)

--- a/src/RuntimeHandler.cs
+++ b/src/RuntimeHandler.cs
@@ -282,6 +282,7 @@ namespace CivOne
 				throw new Exception("Only one runtime can be registered.");
 			}
 
+			ConfigureTranslation(runtime);
 			_instance = new RuntimeHandler(runtime, CreateQuickSaveLoadHotkeyService(runtime));
 		}
 		public static void RegisterForTest(IRuntime runtime)
@@ -291,14 +292,41 @@ namespace CivOne
 				throw new Exception("Only one runtime can be registered.");
 			}
 
+			ConfigureTranslation(runtime);
 			_instance = new RuntimeHandler(runtime, CreateQuickSaveLoadHotkeyService(runtime), false);
 		}
 
 		private static IQuickSaveLoadHotkeyService CreateQuickSaveLoadHotkeyService(IRuntime runtime)
 		{
-			ITranslationService translationService = TranslationServiceFactory.CreateDefault();
+			ITranslationService translationService = TranslationServiceFactory.GetCurrent();
 			IYamlSaveGameServiceFactory yamlSaveGameServiceFactory = new YamlSaveGameServiceFactory();
 			return new QuickSaveLoadHotkeyService(runtime, translationService, yamlSaveGameServiceFactory);
+		}
+
+		private static void ConfigureTranslation(IRuntime runtime)
+		{
+			string languagePostfix = runtime.Settings.LanguagePostfix;
+			if (string.IsNullOrEmpty(languagePostfix))
+			{
+				// During registration RuntimeHandler.Runtime is not assigned yet,
+				// so Settings.Instance would recurse into an uninitialized runtime.
+				languagePostfix = runtime.GetSetting("LanguagePostfix");
+			}
+
+			if (string.IsNullOrEmpty(languagePostfix))
+			{
+				TranslationServiceFactory.UseIdentity();
+				return;
+			}
+
+			if (TranslationServiceFactory.TryUseLanguage(runtime.StorageDirectory, languagePostfix, out string error, message => runtime.Log(message)))
+			{
+				runtime.Log("Translation language activated: {0}", languagePostfix);
+				return;
+			}
+
+			runtime.Log("Could not activate translation language '{0}': {1}", languagePostfix, error);
+			TranslationServiceFactory.UseIdentity();
 		}
 
         /// <summary>

--- a/src/RuntimeSettings.cs
+++ b/src/RuntimeSettings.cs
@@ -26,6 +26,7 @@ namespace CivOne
 
 		public Tuple<char, int> LoadSaveGameSlot { get; set; } = null;
 		public string LoadCosFile { get; set; } = null;
+		public string LanguagePostfix { get; set; } = null;
 		public static Tuple<char, int> UseLoadingScreen => new Tuple<char, int>('0', -1);
 
         // fire-eggs 20190711 allow specifying the initial RNG seed for game repeatability/debugging

--- a/src/Screens/Credits.cs
+++ b/src/Screens/Credits.cs
@@ -219,16 +219,16 @@ namespace CivOne.Screens
             _noiseCounter = 0;
         }
 
-		// liefert eine Liste (später übersetzt) der menu items zurück
+		// Returns menu items resolved through the active translation service.
 		private string[] GetMenuItems()
 		{
 			return
 			[
-				"Start a New Game",
-				"Load a Saved Game",
-				"EARTH",
-				"Customize World",
-				"View Hall of Fame"
+				Translate("Start a New Game"),
+				Translate("Load a Saved Game"),
+				Translate("EARTH"),
+				Translate("Customize World"),
+				Translate("View Hall of Fame")
 			];
 		}
 

--- a/src/Screens/Setup.cs
+++ b/src/Screens/Setup.cs
@@ -8,11 +8,15 @@
 // work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using CivOne.Enums;
 using CivOne.Events;
 using CivOne.Graphics;
 using CivOne.IO;
+using CivOne.Services;
+using CivOne.Services.Translation;
+using CivOne.Tasks;
 using CivOne.UserInterface;
 
 using static CivOne.Enums.AspectRatio;
@@ -574,37 +578,35 @@ namespace CivOne.Screens
 		);
 
 		private void BehaviorMenu(int activeItem = 0) => CreateMenu("Game behavior menu", activeItem,
-			[
-					MenuItem.Create($"Use smart PathFinding for \"goto\": {Settings.PathFinding.YesNo()}")
-						.WithDescription(
-							"Improve goto route selection for player units.")
-						.OnSelect(GotoMenu(PathFindingMenu)),
-					MenuItem.Create($"Use smart pathfinding for computer players: {Settings.ComputerPlayerPathFinding.YesNo()}")
-						.WithDescription(
-							"Improve route selection for AI controlled units.")
-						.OnSelect(GotoMenu(ComputerPlayerPathFindingMenu)),
-					MenuItem.Create($"Use auto-settlers-cheat: {Settings.AutoSettlers.YesNo()}")
-						.WithDescription(
-							"Allow cheat behavior for automatic settlers.")
-						.OnSelect(GotoMenu(AutoSettlersMenu)),
-					MenuItem.Create($"Use fast river movement: {Settings.RiverFastMovement.YesNo()}")
-						.WithDescription(
-							"Rivers act closer to roads for movement speed.")
-						.OnSelect(GotoMenu(FastRiverMovementMenu)),
-					MenuItem.Create($"No movement penalty for sea units in city: {Settings.CanalCity.YesNo()}")
-						.WithDescription(
-							"Sea units ignore city movement penalty.")
-						.OnSelect(GotoMenu(CanalCity)),
-					MenuItem.Create($"Remove obsolete buildings: {Settings.RemoveObsoleteBuildings.YesNo()}")
-						.WithDescription(
-							"Remove buildings when technology obsoletes them.")
-						.OnSelect(GotoMenu(RemoveObsoleteBuildingsMenu)),
-					MenuItem.Create($"Extended global warming: {(Settings.GlobalWarmingFeatureFlags != Settings.GlobalWarmingFeatureFlag.None).YesNo()}")
-						.WithDescription(
-							"Enable extra global warming gameplay effects.")
-						.OnSelect(GotoMenu(ExtendedGlobalWarmingMenu)),
-					MenuItem.Create("Back").OnSelect(GotoMenu(PatchesMenu, 8))
-			]
+			MenuItem.Create($"Use smart PathFinding for \"goto\": {Settings.PathFinding.YesNo()}")
+				.WithDescription(
+					"Improve goto route selection for player units.")
+				.OnSelect(GotoMenu(PathFindingMenu)),
+			MenuItem.Create($"Use smart pathfinding for computer players: {Settings.ComputerPlayerPathFinding.YesNo()}")
+				.WithDescription(
+					"Improve route selection for AI controlled units.")
+				.OnSelect(GotoMenu(ComputerPlayerPathFindingMenu)),
+			MenuItem.Create($"Use auto-settlers-cheat: {Settings.AutoSettlers.YesNo()}")
+				.WithDescription(
+					"Allow cheat behavior for automatic settlers.")
+				.OnSelect(GotoMenu(AutoSettlersMenu)),
+			MenuItem.Create($"Use fast river movement: {Settings.RiverFastMovement.YesNo()}")
+				.WithDescription(
+					"Rivers act closer to roads for movement speed.")
+				.OnSelect(GotoMenu(FastRiverMovementMenu)),
+			MenuItem.Create($"No movement penalty for sea units in city: {Settings.CanalCity.YesNo()}")
+				.WithDescription(
+					"Sea units ignore city movement penalty.")
+				.OnSelect(GotoMenu(CanalCity)),
+			MenuItem.Create($"Remove obsolete buildings: {Settings.RemoveObsoleteBuildings.YesNo()}")
+				.WithDescription(
+					"Remove buildings when technology obsoletes them.")
+				.OnSelect(GotoMenu(RemoveObsoleteBuildingsMenu)),
+			MenuItem.Create($"Extended global warming: {(Settings.GlobalWarmingFeatureFlags != Settings.GlobalWarmingFeatureFlag.None).YesNo()}")
+				.WithDescription(
+					"Enable extra global warming gameplay effects.")
+				.OnSelect(GotoMenu(ExtendedGlobalWarmingMenu)),
+			MenuItem.Create("Back").OnSelect(GotoMenu(PatchesMenu, 8))
 		);
 
 		private void PluginsMenu(int activeItem = 0) => CreateMenu("Plugins", activeItem,
@@ -651,6 +653,7 @@ namespace CivOne.Screens
 			MenuItem.Create($"Civilopedia Text: {Settings.CivilopediaText.ToText()}").OnSelect(GotoMenu(GameOptionMenu(6, "Civilopedia Text", () => Settings.CivilopediaText, (GameOption option) => Settings.CivilopediaText = option))),
 			MenuItem.Create($"Palace: {Settings.Palace.ToText()}").OnSelect(GotoMenu(GameOptionMenu(7, "Palace", () => Settings.Palace, (GameOption option) => Settings.Palace = option))),
 			MenuItem.Create($"Tax Rate: {Settings.TaxRate * 10}%").OnSelect(GotoMenu(TaxRateMenu)),
+			MenuItem.Create($"Language: {CurrentLanguageText()}").OnSelect(GotoMenu(LanguageMenu)),
 			MenuItem.Create("Back").OnSelect(GotoMenu(MainMenu, 3))
 		);
 
@@ -675,6 +678,74 @@ namespace CivOne.Screens
 			MenuItem.Create("100% Tax,  0% Science").OnSelect((s, a) => Settings.TaxRate = 10).SetActive(() => Settings.TaxRate == 10),
 			MenuItem.Create("Back")
 		);
+
+		private string CurrentLanguageText()
+		{
+			string activePostfix = TranslationServiceFactory.ActiveLanguagePostfix;
+			return string.IsNullOrEmpty(activePostfix) ? "Identity" : activePostfix;
+		}
+
+		private void LanguageMenu()
+		{
+			IReadOnlyList<TranslationLanguageInfo> availableLanguages = TranslationServiceFactory.GetAvailableLanguages(Runtime.StorageDirectory, message => Log(message));
+			List<MenuItem<int>> menuItems =
+			[
+				MenuItem.Create("Identity (default)").OnSelect((s, a) => SelectLanguage(string.Empty)).SetActive(() => string.IsNullOrEmpty(TranslationServiceFactory.ActiveLanguagePostfix))
+			];
+
+			if (availableLanguages.Count == 0)
+			{
+				menuItems.Add(MenuItem.Create("No valid language files found.").Disable());
+				menuItems.Add(MenuItem.Create("Add civ_xx.txt to .../translations.").Disable());
+			}
+			else
+			{
+				menuItems.AddRange(availableLanguages.Select(language => language.Postfix)
+					.Select(postfix => MenuItem.Create(postfix)
+						.OnSelect((s, a) => SelectLanguage(postfix))
+						.SetActive(() => string.Equals(TranslationServiceFactory.ActiveLanguagePostfix, postfix, StringComparison.Ordinal))));
+			}
+
+			menuItems.Add(MenuItem.Create("Back"));
+			CreateMenu("Language", GotoMenu(GameOptionsMenu, 9), [.. menuItems]);
+		}
+
+		private void SelectLanguage(string postfix)
+		{
+			if (string.IsNullOrEmpty(postfix))
+			{
+				Settings.LanguagePostfix = string.Empty;
+				TranslationServiceFactory.UseIdentity();
+				NotifyLanguageSelection("Identity");
+				GameOptionsMenu(9);
+				return;
+			}
+
+			if (!TranslationServiceFactory.TryUseLanguage(Runtime.StorageDirectory, postfix, out string error, message => Log(message)))
+			{
+				Log("Could not activate language '{0}': {1}", postfix, error);
+				if (Game.Started)
+				{
+					GameTask.Enqueue(Message.Error("Language", $"Could not load language '{postfix}'.", error));
+				}
+				GameOptionsMenu(9);
+				return;
+			}
+
+			Settings.LanguagePostfix = postfix;
+			NotifyLanguageSelection(postfix);
+			GameOptionsMenu(9);
+		}
+
+		private void NotifyLanguageSelection(string languageName)
+		{
+			if (!Game.Started)
+			{
+				return;
+			}
+
+			GameTask.Enqueue(Message.General($"Language switched to {languageName}."));
+		}
 
 		private void Resize(object sender, ResizeEventArgs args)
 		{

--- a/src/Services/GameCalendarService.cs
+++ b/src/Services/GameCalendarService.cs
@@ -15,7 +15,7 @@ namespace CivOne.Services
 	/// </summary>
 	public class GameCalendarService(ITranslationService _translationService = null)
 	{
-		private readonly ITranslationService _translation = _translationService ?? new TranslationIdentityServiceImpl();
+		private readonly ITranslationService _translation = _translationService ?? TranslationServiceFactory.GetCurrent();
 
 		/// <summary>
 		/// Converts a calendar year to the corresponding game turn.

--- a/src/Services/ITranslationService.cs
+++ b/src/Services/ITranslationService.cs
@@ -11,7 +11,11 @@ using System;
 
 namespace CivOne.Services
 {
-
+	/// <summary>
+	/// Defines the runtime translation contract used by UI and gameplay services.
+	/// Implementations include identity fallback (<see cref="TranslationIdentityServiceImpl"/>) and file-based lookup
+	/// (<see cref="Translation.FileTranslationServiceImpl"/>).
+	/// </summary>
 	public interface ITranslationService
 	{
 		/// <summary>

--- a/src/Services/SaveMetaDataService.cs
+++ b/src/Services/SaveMetaDataService.cs
@@ -17,7 +17,7 @@ namespace CivOne.Services
 	/// </summary>
 	public class SaveMetaDataService(string _gameVersion, ITranslationService _translationService = null)
 	{
-		private readonly ITranslationService _translation = _translationService ?? new TranslationIdentityServiceImpl();
+		private readonly ITranslationService _translation = _translationService ?? TranslationServiceFactory.GetCurrent();
 		private readonly GameCalendarService _calendar;
 
 		public SaveMetaDataService(string gameVersion, ITranslationService translationService, GameCalendarService calendar)

--- a/src/Services/Translation/FileTranslationServiceImpl.cs
+++ b/src/Services/Translation/FileTranslationServiceImpl.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace CivOne.Services.Translation
+{
+	/// <summary>
+	/// File-backed translation service.
+	/// Performs case-insensitive key lookup from a preloaded dictionary and falls back to
+	/// <see cref="TranslationIdentityServiceImpl"/> (or a provided fallback service) for missing keys.
+	/// </summary>
+	public class FileTranslationServiceImpl(IReadOnlyDictionary<string, string> translations, ITranslationService fallback = null) : ITranslationService
+	{
+		private readonly IReadOnlyDictionary<string, string> _translations = translations ?? throw new ArgumentNullException(nameof(translations));
+		private readonly ITranslationService _fallback = fallback ?? new TranslationIdentityServiceImpl();
+
+		/// <inheritdoc/>
+		public string Translate(string key)
+		{
+			string normalized = NormalizeKey(key);
+			if (normalized.Length == 0)
+			{
+				return _fallback.Translate(key);
+			}
+
+			if (_translations.TryGetValue(normalized, out string translated))
+			{
+				return translated;
+			}
+
+			return _fallback.Translate(key);
+		}
+
+		/// <inheritdoc/>
+		public string TranslateFormatted(string key, params object[] args)
+		{
+			string formatText = Translate(key);
+			return string.Format(formatText, args);
+		}
+
+		private static string NormalizeKey(string key) => key?.Trim().ToUpperInvariant() ?? string.Empty;
+	}
+}

--- a/src/Services/Translation/ITranslationFileRepository.cs
+++ b/src/Services/Translation/ITranslationFileRepository.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace CivOne.Services.Translation
+{
+	/// <summary>
+	/// Abstraction for discovering language files and loading translation key-value data from disk.
+	/// Used by <see cref="CivOne.Services.TranslationServiceFactory"/>.
+	/// </summary>
+	public interface ITranslationFileRepository
+	{
+		/// <summary>
+		/// Returns all valid language files found in the runtime storage directory.
+		/// </summary>
+		IReadOnlyList<TranslationLanguageInfo> GetAvailableLanguages(string storageDirectory, Action<string> log = null);
+
+		/// <summary>
+		/// Tries to load translation entries from a language file.
+		/// </summary>
+		bool TryLoadTranslations(string filePath, out IReadOnlyDictionary<string, string> translations, out string error);
+	}
+}

--- a/src/Services/Translation/TranslationFileRepositoryImpl.cs
+++ b/src/Services/Translation/TranslationFileRepositoryImpl.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CivOne.Services.Translation
+{
+	/// <summary>
+	/// Default file-system based implementation of <see cref="ITranslationFileRepository"/>.
+	/// Reads translation files from the runtime translation directory and validates file structure.
+	/// </summary>
+	public class TranslationFileRepositoryImpl : ITranslationFileRepository
+	{
+		private const string EqualsPlaceholder = "[EQ]";
+
+		/// <inheritdoc/>
+		public IReadOnlyList<TranslationLanguageInfo> GetAvailableLanguages(string storageDirectory, Action<string> log = null)
+		{
+			if (string.IsNullOrWhiteSpace(storageDirectory))
+			{
+				return [];
+			}
+
+			string translationDirectory = GetTranslationDirectory(storageDirectory);
+			if (!Directory.Exists(translationDirectory))
+			{
+				return [];
+			}
+
+			List<TranslationLanguageInfo> output = [];
+			foreach (string filePath in Directory.EnumerateFiles(translationDirectory, "*.txt", SearchOption.TopDirectoryOnly)
+				.OrderBy(path => path, StringComparer.OrdinalIgnoreCase))
+			{
+				string fileName = Path.GetFileName(filePath);
+				if (!TryGetPostfix(fileName, out string postfix))
+				{
+					continue;
+				}
+
+				if (!TryLoadTranslations(filePath, out _, out string error))
+				{
+					log?.Invoke($"Skipping translation file '{fileName}': {error}");
+					continue;
+				}
+
+				output.Add(new TranslationLanguageInfo(postfix, filePath));
+			}
+
+			return output;
+		}
+
+		/// <inheritdoc/>
+		public bool TryLoadTranslations(string filePath, out IReadOnlyDictionary<string, string> translations, out string error)
+		{
+			translations = null;
+			error = null;
+
+			if (string.IsNullOrWhiteSpace(filePath))
+			{
+				error = "File path is empty.";
+				return false;
+			}
+
+			if (!File.Exists(filePath))
+			{
+				error = $"File not found: {filePath}";
+				return false;
+			}
+
+			Dictionary<string, string> output = new(StringComparer.OrdinalIgnoreCase);
+			try
+			{
+				string[] lines = File.ReadAllLines(filePath);
+				for (int i = 0; i < lines.Length; i++)
+				{
+					string line = lines[i];
+					if (string.IsNullOrWhiteSpace(line))
+					{
+						continue;
+					}
+
+					if (line.StartsWith('#'))
+					{
+						continue;
+					}
+
+					int separatorIndex = line.IndexOf('=');
+					if (separatorIndex < 0)
+					{
+						error = $"Malformed line {i + 1}: missing '=' separator.";
+						return false;
+					}
+
+					string key = NormalizeKey(UnescapeEquals(line[..separatorIndex]));
+					if (key.Length == 0)
+					{
+						error = $"Malformed line {i + 1}: empty key.";
+						return false;
+					}
+
+					string value = UnescapeEquals(line[(separatorIndex + 1)..]);
+					output[key] = value;
+				}
+			}
+			catch (Exception ex)
+			{
+				error = ex.Message;
+				return false;
+			}
+
+			translations = output;
+			return true;
+		}
+
+		private static bool TryGetPostfix(string fileName, out string postfix)
+		{
+			postfix = null;
+			if (string.IsNullOrEmpty(fileName)
+				|| !fileName.StartsWith("civ_", StringComparison.Ordinal)
+				|| !fileName.EndsWith(".txt", StringComparison.Ordinal))
+			{
+				return false;
+			}
+
+			postfix = fileName[4..^4];
+			return postfix.Length > 0;
+		}
+
+		private static string GetTranslationDirectory(string storageDirectory) => Path.Combine(storageDirectory, "translations");
+
+		private static string NormalizeKey(string key) => key?.Trim().ToUpperInvariant() ?? string.Empty;
+
+		private static string UnescapeEquals(string value) => value.Replace(EqualsPlaceholder, "=", StringComparison.Ordinal);
+	}
+}

--- a/src/Services/Translation/TranslationLanguageInfo.cs
+++ b/src/Services/Translation/TranslationLanguageInfo.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace CivOne.Services.Translation
+{
+	/// <summary>
+	/// Describes a discovered language file.
+	/// <para>
+	/// Example: <c>civ_german.txt</c> maps to postfix <c>german</c>.
+	/// </para>
+	/// </summary>
+	/// <param name="Postfix">Language postfix extracted from file name pattern <c>civ_&lt;postfix&gt;.txt</c>.</param>
+	/// <param name="FilePath">Absolute path to the language file.</param>
+	public readonly record struct TranslationLanguageInfo(string Postfix, string FilePath)
+	{
+		/// <summary>
+		/// Returns <see langword="true"/> when <paramref name="postfix"/> matches this language postfix exactly.
+		/// </summary>
+		public bool MatchesPostfix(string postfix) => string.Equals(Postfix, postfix, StringComparison.Ordinal);
+	}
+}

--- a/src/Services/TranslationIdentityServiceImpl.cs
+++ b/src/Services/TranslationIdentityServiceImpl.cs
@@ -13,28 +13,22 @@ namespace CivOne.Services
 {
 
 	/// <summary>
-	/// Default translation service implementation that performs no translation and simply returns the input key or formatted string.
-	/// This is used as a fallback when no actual translation service is provided, ensuring that the game can still function without localization while allowing for future integration of a proper translation service.
+	/// Identity translation implementation.
+	/// Returns keys unchanged and only applies string formatting for formatted calls.
+	/// Used as fallback when no language file is active.
 	/// </summary>
 	public class TranslationIdentityServiceImpl : ITranslationService
 	{
+		/// <inheritdoc/>
 		public string Translate(string key)
 		{
 			return key;
 		}
 
+		/// <inheritdoc/>
 		public string TranslateFormatted(string key, params object[] args)
 		{
 			return string.Format(key, args);
-		}
-	}
-
-	public static class TranslationServiceFactory
-	{
-		private static ITranslationService _instance;
-		public static ITranslationService CreateDefault()
-		{
-			return _instance ??= new TranslationIdentityServiceImpl();
 		}
 	}
 }

--- a/src/Services/TranslationServiceFactory.cs
+++ b/src/Services/TranslationServiceFactory.cs
@@ -1,0 +1,156 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using CivOne.Services.Translation;
+
+namespace CivOne.Services
+{
+	/// <summary>
+	/// Central factory and state holder for the currently active translation service.
+	/// Coordinates language discovery and loading through <see cref="ITranslationFileRepository"/>.
+	/// </summary>
+	public static class TranslationServiceFactory
+	{
+		private static readonly Lock _sync = new();
+		private static ITranslationFileRepository _translationFileRepository = new TranslationFileRepositoryImpl();
+		private static ITranslationService _instance;
+		private static string _activeLanguagePostfix;
+
+		/// <summary>
+		/// Returns the active translation service.
+		/// If none is configured yet, initializes and returns <see cref="TranslationIdentityServiceImpl"/>.
+		/// 
+		/// You should instead call <see cref="GetCurrent"/> to get the active service, 
+		/// and only call this method if you explicitly want to initialize a default translation service.
+		/// Currently this is the same as <see cref="GetCurrent"/>, but this method is intended to be used for explicit initialization, while <see cref="GetCurrent"/> is intended for general retrieval of the active service.
+		/// This separation allows for future changes where the default initialization logic might differ from the retrieval logic, without affecting the call sites that just want to get the current service.
+		/// 
+		/// Use it in Tests for example, to explicitly initialize identity translation before running tests that depend on it, without relying on the fact that <see cref="GetCurrent"/> also initializes identity translation when no service is active.
+		/// </summary>
+		public static ITranslationService CreateDefault()
+		{
+			lock (_sync)
+			{
+				return _instance ??= new TranslationIdentityServiceImpl();
+			}
+		}
+
+		/// <summary>
+		/// Returns the currently active translation service instance.
+		/// If no service is active yet, initializes identity translation.
+		/// </summary>
+		public static ITranslationService GetCurrent()
+		{
+			lock (_sync)
+			{
+				return _instance ??= new TranslationIdentityServiceImpl();
+			}
+		}
+
+		/// <summary>
+		/// Gets the active language postfix, or <see langword="null"/> when identity translation is active.
+		/// </summary>
+		public static string ActiveLanguagePostfix
+		{
+			get
+			{
+				lock (_sync)
+				{
+					return _activeLanguagePostfix;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Replaces the repository used to discover and load translation files.
+		/// Useful for tests and custom repository implementations.
+		/// </summary>
+		public static void ConfigureRepository(ITranslationFileRepository repository)
+		{
+			if (repository == null)
+			{
+				throw new ArgumentNullException(nameof(repository));
+			}
+
+			lock (_sync)
+			{
+				_translationFileRepository = repository;
+			}
+		}
+
+		/// <summary>
+		/// Returns all valid language files for the given storage directory.
+		/// </summary>
+		public static IReadOnlyList<TranslationLanguageInfo> GetAvailableLanguages(string storageDirectory, Action<string> log = null)
+		{
+			lock (_sync)
+			{
+				return _translationFileRepository.GetAvailableLanguages(storageDirectory, log);
+			}
+		}
+
+		/// <summary>
+		/// Activates identity translation and clears active language metadata.
+		/// </summary>
+		public static void UseIdentity()
+		{
+			lock (_sync)
+			{
+				_instance = new TranslationIdentityServiceImpl();
+				_activeLanguagePostfix = null;
+			}
+		}
+
+		/// <summary>
+		/// Tries to activate a language by postfix.
+		/// Loads translations from file and swaps the active implementation to
+		/// <see cref="FileTranslationServiceImpl"/> when successful.
+		/// </summary>
+		/// <param name="storageDirectory">Runtime storage root containing the translation folder.</param>
+		/// <param name="postfix">Language postfix from file name pattern <c>civ_&lt;postfix&gt;.txt</c>.</param>
+		/// <param name="error">Error text on failure; otherwise <see langword="null"/>.</param>
+		/// <param name="log">Optional logger used during language discovery/loading.</param>
+		public static bool TryUseLanguage(string storageDirectory, string postfix, out string error, Action<string> log = null)
+		{
+			error = null;
+
+			if (string.IsNullOrEmpty(postfix))
+			{
+				UseIdentity();
+				return true;
+			}
+
+			lock (_sync)
+			{
+				IReadOnlyList<TranslationLanguageInfo> languages = _translationFileRepository.GetAvailableLanguages(storageDirectory, log);
+				if (!languages.Any(language => language.MatchesPostfix(postfix)))
+				{
+					error = $"Language postfix '{postfix}' not found.";
+					return false;
+				}
+
+				TranslationLanguageInfo languageInfo = languages.First(language => language.MatchesPostfix(postfix));
+
+				if (!_translationFileRepository.TryLoadTranslations(languageInfo.FilePath, out IReadOnlyDictionary<string, string> translations, out string fileError))
+				{
+					error = fileError;
+					return false;
+				}
+
+				_instance = new FileTranslationServiceImpl(translations);
+				_activeLanguagePostfix = languageInfo.Postfix;
+				return true;
+			}
+		}
+	}
+}

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -72,6 +72,7 @@ namespace CivOne
 		private bool _canalCity = false;
 		private bool _removeObsoleteBuildings = true;
 		private bool _preferSveSaveFormat = true;
+		private string _languagePostfix = string.Empty;
 		private bool _useUncheckedCastSanitizer = false;
 		private GlobalWarmingFeatureFlag _globalWarmingFeatureFlags = GlobalWarmingFeatureFlag.None;
         private bool _autoSettlers;
@@ -554,6 +555,17 @@ namespace CivOne
 			set => SetSetting("DisabledPlugins", string.Join(";", value));
 		}
 
+		public string LanguagePostfix
+		{
+			get => _languagePostfix;
+			set
+			{
+				_languagePostfix = value ?? string.Empty;
+				SetSetting("LanguagePostfix", _languagePostfix);
+				Common.ReloadSettings = true;
+			}
+		}
+
 		internal void RevealWorldCheat() => _revealWorld = !_revealWorld;
 		
 		//internal int ScaleX => _scale;
@@ -652,6 +664,7 @@ namespace CivOne
 			GetSetting("CanalCity", ref _canalCity);
 			GetSetting("RemoveObsoleteBuildings", ref _removeObsoleteBuildings);
 			GetSetting("PreferSveSaveFormat", ref _preferSveSaveFormat);
+			GetSetting("LanguagePostfix", ref _languagePostfix);
 			GetSetting("UseUncheckedCastSanitizer", ref _useUncheckedCastSanitizer);
 			GetSetting<CursorType>("CursorType", ref _cursorType);
 			GetSetting<DestroyAnimation>("DestroyAnimation", ref _destroyAnimation);

--- a/translate.ps1
+++ b/translate.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$projectPath = Join-Path $scriptRoot 'civtranslate/civtranslate.csproj'
+$inputPath = Join-Path $scriptRoot 'src'
+$outputDir = Join-Path $scriptRoot 'translation'
+$outputPath = Join-Path $outputDir 'all.txt'
+
+if (!(Test-Path -Path $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir | Out-Null
+}
+
+dotnet run --project $projectPath -- $inputPath --output $outputPath

--- a/translate.sh
+++ b/translate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PROJECT_PATH="$SCRIPT_DIR/civtranslate/civtranslate.csproj"
+INPUT_PATH="$SCRIPT_DIR/src"
+OUTPUT_DIR="$SCRIPT_DIR/translation"
+OUTPUT_PATH="$OUTPUT_DIR/all.txt"
+
+mkdir -p "$OUTPUT_DIR"
+
+dotnet run --project "$PROJECT_PATH" -- "$INPUT_PATH" --output "$OUTPUT_PATH"

--- a/translation/all.txt
+++ b/translation/all.txt
@@ -1,0 +1,15 @@
+BC=BC
+AD=AD
+FAST SAVE IS NOT AVAILABLE RIGHT NOW.=Fast save is not available right now.
+COULD NOT SAVE FAST SAVE SLOT.=Could not save fast save slot.
+FAST SAVE SLOT IS EMPTY.=Fast save slot is empty.
+COULD NOT LOAD FAST SAVE SLOT.=Could not load fast save slot.
+QUICK SAVE/LOAD=Quick Save/Load
+IN {3} LEADER {0} {1} OF THE {2}=In {3} leader {0} {1} of the {2}
+LORD=Lord
+PRINCE=Prince
+KING=King
+EMPEROR=Emperor
+DEITY=Deity
+CHIEF=Chief
+FAST SAVE1 IS NOT AVAILABLE RIGHT NOW.=Fast save1 is not available right now.

--- a/translation/all.txt
+++ b/translation/all.txt
@@ -1,4 +1,4 @@
-# CivOne - General translation file TEST
+# CivOne - General translation file
 # This file is used to list all translation keys and their default English values.
 # See README.md from civtranslate for instructions on how to create a translation file for a specific language.
 

--- a/translation/all.txt
+++ b/translation/all.txt
@@ -1,3 +1,16 @@
+# CivOne - General translation file TEST
+# This file is used to list all translation keys and their default English values.
+# See README.md from civtranslate for instructions on how to create a translation file for a specific language.
+
+START A NEW GAME=Start a New Game
+LOAD A SAVED GAME=Load a Saved Game
+EARTH=EARTH
+CUSTOMIZE WORLD=Customize World
+VIEW HALL OF FAME=View Hall of Fame
+NO FAST SAVEGAMES AVAILABLE. USE CTRL+F1-F10 TO SAVE.=No fast savegames available. Use Ctrl+F1-F10 to save.
+QUICK LOAD SLOTS=Quick Load Slots
+CITY NOT FOUND.=City not found.
+WHERE IN THE HECK IS ... (CITY NAME)=Where in the heck is ... (city name)
 BC=BC
 AD=AD
 FAST SAVE IS NOT AVAILABLE RIGHT NOW.=Fast save is not available right now.

--- a/translation/civ_german.txt
+++ b/translation/civ_german.txt
@@ -1,0 +1,21 @@
+# CivOne - German translation file
+# This file is used to provide German translations for the game.
+BC=v.Chr.
+AD=n.Chr.
+FAST SAVE IS NOT AVAILABLE RIGHT NOW.=Schnellspeichern ist derzeit nicht verfügbar.
+COULD NOT SAVE FAST SAVE SLOT.=Konnte den Schnellspeicherplatz nicht speichern.
+FAST SAVE SLOT IS EMPTY.=Schnellspeicherplatz ist leer.
+COULD NOT LOAD FAST SAVE SLOT.=Konnte den Schnellspeicherplatz nicht laden.
+QUICK SAVE/LOAD=Schnellspeichern/Laden
+IN {3} LEADER {0} {1} OF THE {2}=In {3} Anführer {0} {1} von {2}
+LORD=Herr
+PRINCE=Prinz
+KING=König
+EMPEROR=Kaiser
+DEITY=Gottheit
+CHIEF=Häuptling
+START A NEW GAME=Neues Spiel starten
+LOAD A SAVED GAME=Spiel laden
+EARTH=ERDE
+CUSTOMIZE WORLD=Welt anpassen
+VIEW HALL OF FAME=Ruhmeshalle anzeigen

--- a/xunit/src/QuickSaveLoadHotkeyServiceTests.cs
+++ b/xunit/src/QuickSaveLoadHotkeyServiceTests.cs
@@ -192,7 +192,7 @@ namespace CivOne.UnitTests
 			Action<IReadOnlyList<int>, Action<int>> showQuickLoadMenu = null)
 			=> new(
 				_runtime,
-				TranslationServiceFactory.CreateDefault(),
+				TranslationServiceFactory.GetCurrent(),
 				null,
 				(_, _) => { },
 				save,

--- a/xunit/src/TranslationFileRepositoryImplTests.cs
+++ b/xunit/src/TranslationFileRepositoryImplTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using CivOne.Services.Translation;
+using Xunit;
+
+namespace CivOne.UnitTests
+{
+	public class TranslationFileRepositoryImplTests : IDisposable
+	{
+		private readonly string _storageDirectory;
+		private readonly string _translationDirectory;
+		private readonly TranslationFileRepositoryImpl _testee;
+
+		public TranslationFileRepositoryImplTests()
+		{
+			_storageDirectory = Path.Combine(Path.GetTempPath(), "CivOneTests", Guid.NewGuid().ToString("N"));
+			_translationDirectory = Path.Combine(_storageDirectory, "translations");
+			Directory.CreateDirectory(_translationDirectory);
+			_testee = new TranslationFileRepositoryImpl();
+		}
+
+		[Fact]
+		public void GetAvailableLanguages_ReturnsOnlyValidCivFiles()
+		{
+			File.WriteAllText(Path.Combine(_translationDirectory, "civ_german.txt"), "HELLO=Hallo");
+			File.WriteAllText(Path.Combine(_translationDirectory, "civ_invalid.txt"), "malformed-line");
+			File.WriteAllText(Path.Combine(_translationDirectory, "all.txt"), "HELLO=Hallo");
+			File.WriteAllText(Path.Combine(_translationDirectory, "CIV_upper.txt"), "HELLO=Hallo");
+
+			var actual = _testee.GetAvailableLanguages(_storageDirectory);
+
+			Assert.Single(actual);
+			Assert.Equal("german", actual[0].Postfix);
+		}
+
+		[Fact]
+		public void TryLoadTranslations_NormalizesKeyAndUnescapesEqualsPlaceholder()
+		{
+			string filePath = Path.Combine(_translationDirectory, "civ_german.txt");
+			File.WriteAllText(filePath, "quick save/load=Quick Save/Load\nA[EQ]B=X[EQ]Y\n");
+
+			bool success = _testee.TryLoadTranslations(filePath, out var translations, out var error);
+
+			Assert.True(success);
+			Assert.Null(error);
+			Assert.Equal("Quick Save/Load", translations["QUICK SAVE/LOAD"]);
+			Assert.Equal("X=Y", translations["A=B"]);
+		}
+
+		[Fact]
+		public void TryLoadTranslations_WithMalformedLine_ReturnsFalse()
+		{
+			string filePath = Path.Combine(_translationDirectory, "civ_german.txt");
+			File.WriteAllText(filePath, "HELLO=Hallo\nmalformed\n");
+
+			bool success = _testee.TryLoadTranslations(filePath, out _, out var error);
+
+			Assert.False(success);
+			Assert.Contains("Malformed line", error, StringComparison.Ordinal);
+		}
+
+		public void Dispose()
+		{
+			if (Directory.Exists(_storageDirectory))
+			{
+				Directory.Delete(_storageDirectory, true);
+			}
+		}
+	}
+}

--- a/xunit/src/TranslationServiceFactoryTests.cs
+++ b/xunit/src/TranslationServiceFactoryTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using CivOne.Services;
+using Xunit;
+
+namespace CivOne.UnitTests
+{
+	public class TranslationServiceFactoryTests : IDisposable
+	{
+		private readonly string _storageDirectory;
+		private readonly string _translationDirectory;
+
+		public TranslationServiceFactoryTests()
+		{
+			_storageDirectory = Path.Combine(Path.GetTempPath(), "CivOneTests", Guid.NewGuid().ToString("N"));
+			_translationDirectory = Path.Combine(_storageDirectory, "translations");
+			Directory.CreateDirectory(_translationDirectory);
+			TranslationServiceFactory.UseIdentity();
+		}
+
+		[Fact]
+		public void TryUseLanguage_WhenLanguageFileExists_ActivatesFileTranslation()
+		{
+			File.WriteAllText(Path.Combine(_translationDirectory, "civ_german.txt"), "HELLO=Hallo");
+
+			bool success = TranslationServiceFactory.TryUseLanguage(_storageDirectory, "german", out var error);
+			var actual = TranslationServiceFactory.CreateDefault().Translate("hello");
+
+			Assert.True(success);
+			Assert.Null(error);
+			Assert.Equal("Hallo", actual);
+			Assert.Equal("german", TranslationServiceFactory.ActiveLanguagePostfix);
+		}
+
+		[Fact]
+		public void TryUseLanguage_WhenSelectedAgain_ReloadsFileFromDisk()
+		{
+			string filePath = Path.Combine(_translationDirectory, "civ_german.txt");
+			File.WriteAllText(filePath, "HELLO=Hallo1");
+
+			bool firstSuccess = TranslationServiceFactory.TryUseLanguage(_storageDirectory, "german", out _);
+			string firstTranslation = TranslationServiceFactory.CreateDefault().Translate("HELLO");
+
+			File.WriteAllText(filePath, "HELLO=Hallo2");
+			bool secondSuccess = TranslationServiceFactory.TryUseLanguage(_storageDirectory, "german", out _);
+			string secondTranslation = TranslationServiceFactory.CreateDefault().Translate("HELLO");
+
+			Assert.True(firstSuccess);
+			Assert.True(secondSuccess);
+			Assert.Equal("Hallo1", firstTranslation);
+			Assert.Equal("Hallo2", secondTranslation);
+		}
+
+		[Fact]
+		public void TryUseLanguage_WhenLanguageMissing_LeavesCurrentLanguageUntouched()
+		{
+			File.WriteAllText(Path.Combine(_translationDirectory, "civ_german.txt"), "HELLO=Hallo");
+			bool initialSuccess = TranslationServiceFactory.TryUseLanguage(_storageDirectory, "german", out _);
+
+			bool missingSuccess = TranslationServiceFactory.TryUseLanguage(_storageDirectory, "missing", out var error);
+			string translationAfterFailure = TranslationServiceFactory.CreateDefault().Translate("HELLO");
+
+			Assert.True(initialSuccess);
+			Assert.False(missingSuccess);
+			Assert.Contains("not found", error, StringComparison.Ordinal);
+			Assert.Equal("Hallo", translationAfterFailure);
+			Assert.Equal("german", TranslationServiceFactory.ActiveLanguagePostfix);
+		}
+
+		public void Dispose()
+		{
+			TranslationServiceFactory.UseIdentity();
+			if (Directory.Exists(_storageDirectory))
+			{
+				Directory.Delete(_storageDirectory, true);
+			}
+		}
+	}
+}


### PR DESCRIPTION
* Feature: Translation system with multi-language support
  * In-game translation is now active.
  * Language can be changed in the setup menu via `Shift+F1` -> `Game Options` -> `Language`.
  * The selected language is applied through `TranslationServiceFactory` and reused by gameplay and UI services.
  * `civtranslate` CLI tool scans `*.cs` files for translation calls and creates/updates translation key-value files.
    * Scans for `.Translate("...")`, `.TranslateFormatted("...", ...)`, and `T("...")` patterns.
    * Normalizes keys to uppercase while keeping values as source text.
    * Writes `key=value` entries and escapes literal `=` as `[EQ]`.
    * Merges with existing output files, preserving comments and handling value overwrites.
    * Writes obsolete keys to `obsoletekeys.txt` in the output directory.
    * Translation files support comment headers (lines starting with `#`).
    * Existing comment headers are preserved when updating files.
  * Translation loader ignores `#` comment lines in language files.
  * `SaveMetaDataService` now resolves translation service via factory to always use the currently active language.