### PR TITLE
fix: correct DistanceToTile east-west wrap calculation

### DIFF
--- a/src/Common.cs
+++ b/src/Common.cs
@@ -257,7 +257,7 @@ namespace CivOne
 		
 		public static bool InCityRange(int x1, int y1, int x2, int y2) => new Rectangle(x2 - 2, y2 - 2, 5, 5).IntersectsWith(new Rectangle(x1, y1, 1, 1));
 		
-		public static int DistanceToTile(int x1, int y1, int x2, int y2) => Math.Max(Math.Min(Math.Abs(x2 - x1), Math.Abs(Map.WIDTH - (x2 - x1))), Math.Abs(y2 - y1));
+		public static int DistanceToTile(int x1, int y1, int x2, int y2) => Math.Max(Math.Min(Math.Abs(x2 - x1), Map.WIDTH - Math.Abs(x2 - x1)), Math.Abs(y2 - y1));
 
         // The above function do not work properly at "dateline"  ( methink is is just a "Math.Abs" that is missing ? )   I use the one below.   JR
         /*  ******************************************************************************************************** */


### PR DESCRIPTION
## Summary

`DistanceToTile` uses `Math.Abs(Map.WIDTH - (x2 - x1))` to compute the wrap-around distance, but when `x2 < x1` the inner expression `(x2 - x1)` is already negative, so `Map.WIDTH - (x2 - x1)` becomes larger than `Map.WIDTH` — and then `Math.Abs` just keeps it large instead of clamping it. The correct formula is `Map.WIDTH - Math.Abs(x2 - x1)`, which always gives the shorter crossing distance.

**Effect of the bug:**
- GoTo / auto-travel units refuse to cross the west↔east map edge (they path around the entire map or give up)
- AI target-selection and city-distance checks underreport any distance that spans the dateline, so the AI avoids the "wrong" side of the world
- The `Distance()` workaround function added in a comment directly below this line was put there for exactly this reason

One character removed, one character added.

## Test plan

- [ ] Set a GoTo order for a unit on the west side of the map targeting a tile on the east side; confirm it crosses the dateline rather than walking the long way around
- [ ] Verify AI settlers and units path sensibly near map edges

🤖 Contributed from [mwerneburg/CivOne](https://github.com/mwerneburg/CivOne) where this was discovered and fixed in production gameplay.