### PR TITLE
fix: Diplomat blocked when entering tile with multiple enemies

### DIFF
--- a/src/Units/Diplomat.cs
+++ b/src/Units/Diplomat.cs
@@ -95,18 +95,13 @@ namespace CivOne.Units
 				return true;
 			}
 
-			IUnit[] units = moveTarget.Units;
+			IUnit[] enemies = moveTarget.Units.Where(u => u.Owner != Owner).ToArray();
 
-			if (units.Length == 1)
+			if (enemies.Length > 0)
 			{
-				IUnit unit = units[0];
-
-                // TODO fire-eggs bribe ocean unit
-				if (Human == Owner && unit.Owner != Owner && unit is BaseUnitLand)
-				{
-					GameTask.Enqueue(Show.DiplomatBribe(unit as BaseUnitLand, this));
-					return true;
-				}
+				if (Human == Owner && enemies.Length == 1 && enemies[0] is BaseUnitLand)
+					GameTask.Enqueue(Show.DiplomatBribe(enemies[0] as BaseUnitLand, this));
+				return false;
 			}
 
 			MovementTo(relX, relY);


### PR DESCRIPTION
## Summary

- `Confront()` checked `units.Length == 1` on all tile units (including friendly units co-stacked with an enemy), so a tile with one friendly + one enemy passed the guard and the Diplomat entered silently
- A tile with multiple enemies also fell through to `MovementTo`, letting the Diplomat walk unchallenged into a defended stack
- The `// TODO fire-eggs bribe ocean unit` comment already hints at the problem — the ownership check was inside the length guard rather than being the guard itself

**Fix:** filter to `enemies` (units owned by another player) first. If any enemies are present, show the bribe dialog only when conditions are right (human player, single enemy, land unit); otherwise block entry. `MovementTo` is only reached when the tile has no enemy units at all.

## Test plan

- [ ] Diplomat moves onto tile with exactly one enemy land unit → bribe dialog appears as before
- [ ] Diplomat moves onto tile with two or more enemy units → movement is blocked
- [ ] Diplomat moves onto tile with one friendly unit and one enemy → blocked (previously entered silently)
- [ ] Diplomat moves onto empty tile or tile with only friendly units → moves normally

🤖 Contributed from [mwerneburg/CivOne](https://github.com/mwerneburg/CivOne) where this was discovered and fixed in production gameplay.