### PR TITLE
fix: two AI Settler bugs causing tight loops

### DIFF
--- a/src/AI.cs
+++ b/src/AI.cs
@@ -50,7 +50,7 @@ namespace CivOne
 				bool validCity = (tile is Grassland || tile is River || tile is Plains) && (tile.City == null);
 				bool validIrrigation = (tile is Grassland || tile is River || tile is Plains || tile is Desert) && (tile.City == null) && (!tile.Mine) && (!tile.Irrigation) && tile.CrossTiles().Any(x => x.IsOcean || x is River || x.Irrigation);
 				bool validMine = (tile is Mountains || tile is Hills) && (tile.City == null) && (!tile.Mine) && (!tile.Irrigation);
-				bool validRoad = (tile.City == null) && tile.Road;
+				bool validRoad = (tile.City == null) && !tile.Road && !tile.RailRoad;
 				int nearestCity = 255;
 				int nearestOwnCity = 255;
 				
@@ -70,6 +70,7 @@ namespace CivOne
 							if (validRoad)
 							{
 								GameTask.Enqueue(Orders.BuildRoad(unit));
+								unit.SkipTurn();
 								return;
 							}
 							break;
@@ -77,6 +78,7 @@ namespace CivOne
 							if (validIrrigation)
 							{
 								GameTask.Enqueue(Orders.BuildIrrigation(unit));
+								unit.SkipTurn();
 								return;
 							}
 							break;
@@ -84,6 +86,7 @@ namespace CivOne
 							if (validMine)
 							{
 								GameTask.Enqueue(Orders.BuildMines(unit));
+								unit.SkipTurn();
 								return;
 							}
 							break;


### PR DESCRIPTION
## Summary

Two independent bugs in AI.cs that both produce a tight game loop when the AI controls Settlers:

**Bug 1 — validRoad condition is inverted**

tile.Road == true means a road *already exists*. So validRoad was only ever true on tiles that do not need a road built. BuildRoad() returns false on those tiles without touching MovesLeft, leaving the Settler stuck with MovesLeft=1 — and the game re-enqueues Turn.Move every tick.

Fix: !tile.Road && !tile.RailRoad (only true when a road is actually needed).

**Bug 2 — missing SkipTurn() after improvement orders**

FoundCity calls SkipTurn() before returning, but the three improvement cases (BuildRoad, BuildIrrigation, BuildMines) did not. Without it MovesLeft stays at 1 and Game.Update re-enqueues Turn.Move in the same tick the improvement order is enqueued, producing the same infinite loop.

Fix: call unit.SkipTurn() in each improvement case before returning.

## Test plan

- [ ] AI Settlers on a tile without a road no longer cause the game to hang
- [ ] AI Settlers correctly build roads, irrigation, and mines over multiple turns rather than looping on one turn
- [ ] AI Settlers on a tile that already has a road move on rather than attempting to rebuild it

Contributed from mwerneburg/CivOne where these were found and fixed during gameplay.