### PR TITLE
fix: restore moves when waking a sleeping unit from the stack popup

### DIFF
--- a/src/Screens/UnitStack.cs
+++ b/src/Screens/UnitStack.cs
@@ -7,6 +7,7 @@
 // You should have received a copy of the CC0 legalcode along with this
 // work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+using System.Drawing;
 using System.Linq;
 using CivOne.Enums;
 using CivOne.Events;
@@ -79,9 +80,12 @@ namespace CivOne.Screens
 					if (uid < 0 || uid >= _units.Length)
 						return true;
 					
-					Game.ActiveUnit = _units[uid];
-					_units[uid].Busy = false;
-                    _units[uid].Goto = System.Drawing.Point.Empty; // fire-eggs 20190612 clear Goto
+					IUnit waking = _units[uid];
+					bool wasAsleep = waking.Busy;
+					waking.Busy = false;
+					if (wasAsleep) waking.MovesLeft = waking.Move;
+					waking.Goto = Point.Empty;
+					Game.ActiveUnit = waking;
 					return true;
 				}
 			}


### PR DESCRIPTION
## Summary

When the UnitStack popup appears and the player clicks a sleeping unit (`Busy = true`), that unit should have its moves restored for the current turn — the player is explicitly intervening to take manual control of it. Currently `MovesLeft` is never touched, so the unit wakes up with nothing to do.

The fix tracks whether the unit was actually asleep before clearing `Busy`, and only restores `MovesLeft` in that case:

```csharp
IUnit waking = _units[uid];
bool wasAsleep = waking.Busy;
waking.Busy = false;
if (wasAsleep) waking.MovesLeft = waking.Move;
waking.Goto = Point.Empty;
Game.ActiveUnit = waking;
```

The `wasAsleep` guard matters: a unit that already moved via GoTo this turn (`Busy = false`, `MovesLeft = 0`) should not get a free second turn just because it appears in the stack popup. Only genuinely sleeping units get their moves back.

The existing GoTo clear (fire-eggs patch) is preserved; the `System.Drawing` using directive is added to allow `Point.Empty` without the full namespace qualifier.

## Test plan

- [ ] Put a unit to sleep (S key). End turn. When it appears in the UnitStack popup on a subsequent turn, click it — it should have a full movement allowance and be ready to act
- [ ] A unit that already moved via GoTo and appears in the stack popup should NOT have its moves restored when clicked

Contributed from mwerneburg/CivOne where this was identified during gameplay.