### PR TITLE
perf: make City.Units O(1) with a maintained home-unit list

### DIFF
--- a/src/City.cs
+++ b/src/City.cs
@@ -962,7 +962,10 @@ namespace CivOne
 			}
 		}
 
-		public IUnit[] Units => Game.Instance.GetUnits().Where(u => u.Home == this).ToArray();
+		private readonly List<IUnit> _homeUnits = new();
+		internal void AddHomeUnit(IUnit unit) { if (!_homeUnits.Contains(unit)) _homeUnits.Add(unit); }
+		internal void RemoveHomeUnit(IUnit unit) => _homeUnits.Remove(unit);
+		public IUnit[] Units => _homeUnits.ToArray();
 
 		public ITile Tile => Map[X, Y];
 

--- a/src/City.cs
+++ b/src/City.cs
@@ -962,7 +962,7 @@ namespace CivOne
 			}
 		}
 
-		private readonly List<IUnit> _homeUnits = new();
+		private readonly List<IUnit> _homeUnits = [];
 		internal void AddHomeUnit(IUnit unit) { if (!_homeUnits.Contains(unit)) _homeUnits.Add(unit); }
 		internal void RemoveHomeUnit(IUnit unit) => _homeUnits.Remove(unit);
 		public IUnit[] Units => _homeUnits.ToArray();

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -768,11 +768,13 @@ namespace CivOne
 				while (unit.Tile.Units.Count(u => u.Class != UnitClass.Water) > totalCargo)
 				{
 					IUnit subUnit = unit.Tile.Units.First(u => u.Class != UnitClass.Water);
+					subUnit.Home?.RemoveHomeUnit(subUnit);
 					subUnit.X = 255;
 					subUnit.Y = 255;
 					_units.Remove(subUnit);
 				}
 			}
+			unit.Home?.RemoveHomeUnit(unit);
 			unit.X = 255;
 			unit.Y = 255;
 			_units.Remove(unit);

--- a/src/Units/BaseUnit.cs
+++ b/src/Units/BaseUnit.cs
@@ -780,7 +780,17 @@ namespace CivOne.Units
 
 		public UnitClass Class { get; protected set; }
 		public UnitType Type { get; protected set; }
-		public City Home { get; private set; }
+		private City _home;
+		public City Home
+		{
+			get => _home;
+			private set
+			{
+				_home?.RemoveHomeUnit(this);
+				_home = value;
+				_home?.AddHomeUnit(this);
+			}
+		}
 
         private short _buyPrice;
 		public short BuyPrice


### PR DESCRIPTION
## Summary

`City.Units` currently scans every unit in the game to find those homed to a city:

```csharp
public IUnit[] Units => Game.Instance.GetUnits().Where(u => u.Home == this).ToArray();
```

`City.Units` is called repeatedly each turn from `ShieldCosts`, `FoodCosts`, `AvailableProduction`, AI strategy, and display code. With 200+ units mid-game spread across 20+ cities, that is tens of thousands of comparisons executed every turn.

This PR replaces it with a maintained list so `City.Units` becomes a single `.ToArray()` copy with no scan.

## Changes

**`City.cs`** — add a `List<IUnit> _homeUnits` with `AddHomeUnit`/`RemoveHomeUnit` accessors; `Units` returns `_homeUnits.ToArray()`.

**`BaseUnit.cs`** — convert `Home` from an auto-property to a backed property whose setter calls `RemoveHomeUnit` on the old city and `AddHomeUnit` on the new one. Both `SetHome()` overloads and the direct `Home = ...` assignment already go through this setter, so all assignment paths are covered without touching call sites.

**`Game.cs`** — `DisbandUnit` does not null out `Home` before removing a unit from `_units`, so it needs two explicit `RemoveHomeUnit` calls: one for the disbanded unit itself and one for any aboard units jettisoned when a transport sinks. Without these the disbanded unit would linger in the city list indefinitely.

## Test plan

- [ ] City shield and food costs remain correct (both use `Units.Count(...)`)
- [ ] `SetHome()` via the menu correctly moves a unit between city lists
- [ ] Disbanding a unit removes it from its home city list
- [ ] Sinking a loaded transport removes the aboard units from their home city lists
- [ ] `AvailableProduction` still correctly suppresses units already homed to the city

Contributed from mwerneburg/CivOne where this pattern has been running in production.
