### PR TITLE
Consolidation PR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,13 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
-* Fix: Stabilized city food caching to prevent stale values after resource tile changes.
-  * `FoodRaw` cache is now validated per game turn and recalculated when needed.
-  * Cache invalidation now runs on relevant city/resource tile mutation paths (owner/size/resource tile updates).
-  * Keeps the performance optimization while ensuring correct `FoodIncome` and `FoodTotal` values.
+* Fix: Stabilized city resource caching to prevent stale values after resource tile changes.
+  * `FoodRaw` cache is now validated via tile/city state hash and recalculated when needed.
+  * Added `ShieldRaw` cache using the same state-hash pattern to avoid repeated `ResourceTiles.Sum(t => ShieldValue(t))` scans.
+  * `ShieldTotal` now consumes `ShieldRaw` before applying building multipliers (Factory, Nuclear Plant, Mfg Plant).
+  * Cache invalidation now clears both food and shield raw caches on relevant city/resource tile mutation paths (owner/size/resource tile updates).
+  * Added focused unit test coverage for shield cache recomputation in `CityEconomyServiceImplCalculateBreakdownTests.ShieldTotal_Recomputes_WhenWorkedTileShieldChangesWithinSameTurn`.
+  * Keeps the performance optimization while ensuring correct `FoodIncome`, `FoodTotal`, and `ShieldTotal` values.
 * Fix: Fix and Migration of [mwerneburg](https://github.com/ChrisWiGit/CivOne/pull/33)
   * Keep city home-unit cache and unit home reference consistent during removal.
   * `DestroyCity(...)` and `DisbandUnit(...)` now clear a unit's home via `SetHome(null)` before removing it from game unit lists.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
+* Consolidated fixes ([PR #38](https://github.com/ChrisWiGit/CivOne/pull/38))
+  * [Issue #31](https://github.com/ChrisWiGit/CivOne/issues/31): Fixed Democracy war declaration flow so Senate blocking is handled correctly.
+  * [Issue #34](https://github.com/ChrisWiGit/CivOne/issues/34): Extended `CityEconomyBreakdown` performance work to include food and shield tile sums.
+  * [PR #30](https://github.com/ChrisWiGit/CivOne/pull/30): Improved unit stack handling so units can be woken up reliably from stacked selections.
+    * Sleeping units do not reset their moves left when selected from the stack, so they cannot move immediately after being woken up if they have already moved before.
+  * [PR #27](https://github.com/ChrisWiGit/CivOne/pull/27): Corrected east-west wrap distance calculation in `DistanceToTile` and related pathfinding distance checks.
+  * [PR #29](https://github.com/ChrisWiGit/CivOne/pull/29): Fixed Settler AI improvement tight-loop by correcting road eligibility and ending the turn after queuing improvement orders.
 * Fix: Stabilized city resource caching to prevent stale values after resource tile changes.
   * `FoodRaw` cache is now validated via tile/city state hash and recalculated when needed.
   * Added `ShieldRaw` cache using the same state-hash pattern to avoid repeated `ResourceTiles.Sum(t => ShieldValue(t))` scans.

--- a/src/AI.cs
+++ b/src/AI.cs
@@ -50,7 +50,9 @@ namespace CivOne
 				bool validCity = (tile is Grassland || tile is River || tile is Plains) && (tile.City == null);
 				bool validIrrigation = (tile is Grassland || tile is River || tile is Plains || tile is Desert) && (tile.City == null) && (!tile.Mine) && (!tile.Irrigation) && tile.CrossTiles().Any(x => x.IsOcean || x is River || x.Irrigation);
 				bool validMine = (tile is Mountains || tile is Hills) && (tile.City == null) && (!tile.Mine) && (!tile.Irrigation);
-				bool validRoad = (tile.City == null) && tile.Road;
+				bool validRoad = (tile.City == null) &&
+									!tile.RailRoad &&
+									(!tile.Road || Player.HasAdvance<RailRoad>());
 				int nearestCity = 255;
 				int nearestOwnCity = 255;
 				City[] cities = Game.GetCities();
@@ -71,6 +73,7 @@ namespace CivOne
 							if (validRoad)
 							{
 								GameTask.Enqueue(Orders.BuildRoad(unit));
+								unit.SkipTurn();
 								return;
 							}
 							break;
@@ -78,6 +81,7 @@ namespace CivOne
 							if (validIrrigation)
 							{
 								GameTask.Enqueue(Orders.BuildIrrigation(unit));
+								unit.SkipTurn();
 								return;
 							}
 							break;
@@ -85,6 +89,7 @@ namespace CivOne
 							if (validMine)
 							{
 								GameTask.Enqueue(Orders.BuildMines(unit));
+								unit.SkipTurn();
 								return;
 							}
 							break;

--- a/src/City.cs
+++ b/src/City.cs
@@ -237,7 +237,7 @@ namespace CivOne
 		{
 			get
 			{
-				int shields = ResourceTiles.Sum(t => ShieldValue(t));
+				int shields = ShieldRaw;
 				if (_buildings.Any(b => (b is Factory))) shields += (short)Math.Floor((double)shields * (_buildings.Any(b => (b is NuclearPlant)) ? 1.0 : 0.5));
 				if (_buildings.Any(b => (b is MfgPlant))) shields += (short)Math.Floor((double)shields * 1.0);
 				return shields;
@@ -287,7 +287,10 @@ namespace CivOne
 		private CityEconomyBreakdown? _cachedCityBreakdown;
 		private int? _cachedFoodRaw;
 		private ulong _cachedFoodRawStateHash = ulong.MaxValue;
+		private int? _cachedShieldRaw;
+		private ulong _cachedShieldRawStateHash = ulong.MaxValue;
 		private const int TileFoodHashOffset = 128;
+		private const int TileShieldHashOffset = 128;
 
 		private CityEconomyBreakdown GetCachedCityBreakdown()
 		{
@@ -303,6 +306,8 @@ namespace CivOne
 			_cachedCityBreakdown = null;
 			_cachedFoodRaw = null;
 			_cachedFoodRawStateHash = ulong.MaxValue;
+			_cachedShieldRaw = null;
+			_cachedShieldRawStateHash = ulong.MaxValue;
 		}
 
 		private int FoodRaw
@@ -317,6 +322,21 @@ namespace CivOne
 				}
 
 				return _cachedFoodRaw.Value;
+			}
+		}
+
+		private int ShieldRaw
+		{
+			get
+			{
+				ulong currentShieldStateHash = GetShieldRawStateHash();
+				if (!_cachedShieldRaw.HasValue || _cachedShieldRawStateHash != currentShieldStateHash)
+				{
+					_cachedShieldRaw = ResourceTiles.Sum(t => ShieldValue(t));
+					_cachedShieldRawStateHash = currentShieldStateHash;
+				}
+
+				return _cachedShieldRaw.Value;
 			}
 		}
 
@@ -338,6 +358,31 @@ namespace CivOne
 					hash = (hash ^ (uint)(tile.Food + TileFoodHashOffset)) * 1099511628211UL;
 					hash = (hash ^ (tile.Special ? 1UL : 0UL)) * 1099511628211UL;
 					hash = (hash ^ (tile.Irrigation ? 1UL : 0UL)) * 1099511628211UL;
+					hash = (hash ^ (tile.RailRoad ? 1UL : 0UL)) * 1099511628211UL;
+					hash = (hash ^ (tile.Pollution ? 1UL : 0UL)) * 1099511628211UL;
+				}
+
+				return hash;
+			}
+		}
+
+		private ulong GetShieldRawStateHash()
+		{
+			unchecked
+			{
+				// FNV-1a 64-bit hash over shield-affecting city/tile state.
+				ulong hash = 1469598103934665603UL;
+
+				hash = (hash ^ (uint)Owner) * 1099511628211UL;
+				hash = (hash ^ (Player.AnarchyDespotism ? 1UL : 0UL)) * 1099511628211UL;
+				foreach (ITile tile in ResourceTiles)
+				{
+					hash = (hash ^ (uint)tile.X) * 1099511628211UL;
+					hash = (hash ^ (uint)tile.Y) * 1099511628211UL;
+					hash = (hash ^ (uint)tile.Type) * 1099511628211UL;
+					// Shield is sbyte (-128..127); shift into 0..255 for stable hashing.
+					hash = (hash ^ (uint)(tile.Shield + TileShieldHashOffset)) * 1099511628211UL;
+					hash = (hash ^ (tile.Mine ? 1UL : 0UL)) * 1099511628211UL;
 					hash = (hash ^ (tile.RailRoad ? 1UL : 0UL)) * 1099511628211UL;
 					hash = (hash ^ (tile.Pollution ? 1UL : 0UL)) * 1099511628211UL;
 				}
@@ -739,32 +784,6 @@ namespace CivOne
 			UpdateSpecialists();
 			SetupCoastalFlag();
 		}
-
-		private void SetResourceTiles2()
-		{
-			if (!Game.Started) return;
-			InvalidateCityBreakdownCache();
-
-			while (_resourceTiles.Count > Size)
-				_resourceTiles.RemoveAt(_resourceTiles.Count - 1);
-			
-			if (_resourceTiles.Count == Size) return;
-			if (_resourceTiles.Count < Size)
-			{
-				IEnumerable<ITile> tiles = CityTiles.Where(
-					t => !OccupiedTile(t) && !ResourceTiles.Contains(t))
-							.OrderByDescending(t => FoodValue(t))
-							.ThenByDescending(t => ShieldValue(t))
-							.ThenByDescending(t => TradeValue(t));
-				if (tiles.Count() > 0)
-					_resourceTiles.Add(tiles.First());
-			}
-
-			UpdateSpecialists();
-
-			SetupCoastalFlag();
-		}
-
 
 		private void SetupCoastalFlag()
 		{

--- a/src/Common.cs
+++ b/src/Common.cs
@@ -257,7 +257,7 @@ namespace CivOne
 		
 		public static bool InCityRange(int x1, int y1, int x2, int y2) => new Rectangle(x2 - 2, y2 - 2, 5, 5).IntersectsWith(new Rectangle(x1, y1, 1, 1));
 		
-		public static int DistanceToTile(int x1, int y1, int x2, int y2) => Math.Max(Math.Min(Math.Abs(x2 - x1), Math.Abs(Map.WIDTH - (x2 - x1))), Math.Abs(y2 - y1));
+		public static int DistanceToTile(int x1, int y1, int x2, int y2) => Math.Max(Math.Min(Math.Abs(x2 - x1), Map.WIDTH - Math.Abs(x2 - x1)), Math.Abs(y2 - y1));
 
         // The above function do not work properly at "dateline"  ( methink is is just a "Math.Abs" that is missing ? )   I use the one below.   JR
         /*  ******************************************************************************************************** */

--- a/src/Screens/UnitStack.cs
+++ b/src/Screens/UnitStack.cs
@@ -7,6 +7,7 @@
 // You should have received a copy of the CC0 legalcode along with this
 // work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+using System.Drawing;
 using System.Linq;
 using CivOne.Enums;
 using CivOne.Events;
@@ -15,15 +16,21 @@ using CivOne.Units;
 
 namespace CivOne.Screens
 {
+	[ScreenResizeable]
 	internal class UnitStack : BaseScreen
 	{
-		private const int XX = 101;
 		private const int WIDTH = 121;
+		private const int UnitRowHeight = 16;
+		private const int VerticalPadding = 3;
+		private const int DialogHeightPadding = 6;
 
-		private readonly int _x, _y;
 		private readonly IUnit[] _units;
 
 		private bool _update = true;
+
+		private int DialogHeight => (_units.Length * UnitRowHeight) + DialogHeightPadding;
+		private int DialogLeft => (CanvasWidth - WIDTH) / 2;
+		private int DialogTop => (CanvasHeight - DialogHeight) / 2;
 		
 		protected override bool HasUpdate(uint gameTick)
 		{
@@ -36,8 +43,9 @@ namespace CivOne.Screens
 					return true;
 				}
 
-				int height = (16 * _units.Length) + 6;
-				int yy = (200 - height) / 2;
+				int left = DialogLeft;
+				int top = DialogTop;
+				int height = DialogHeight;
 
 				Picture dialog = new Picture(WIDTH, height)
 					.FillRectangle(1, 1, WIDTH - 2, height - 2, 3)
@@ -52,12 +60,19 @@ namespace CivOne.Screens
 						.DrawText(unit.Home == null ? "NONE" : unit.Home.Name, 0, 14, 27, (i * 16) + 12);
 				}
 
-				this.FillRectangle(XX - 1, yy - 1, WIDTH + 2, height + 2, 5)
-					.AddLayer(dialog, XX, yy);
+				this.FillRectangle(left - 1, top - 1, WIDTH + 2, height + 2, 5)
+					.AddLayer(dialog, left, top);
+				_update = false;
 				
 				return true;
 			}
 			return false;
+		}
+
+		protected override void Resize(int width, int height)
+		{
+			_update = true;
+			base.Resize(width, height);
 		}
 		
 		public override bool KeyDown(KeyboardEventArgs args)
@@ -66,35 +81,74 @@ namespace CivOne.Screens
 			return true;
 		}
 		
-		public override bool MouseDown(ScreenEventArgs args)
+		public bool MouseDown2(ScreenEventArgs args)
 		{
-			if (args.X >= XX && args.X < (XX + WIDTH))
+			int left = DialogLeft;
+			int top = DialogTop;
+			int height = DialogHeight;
+
+			if (args.X >= left && args.X < (left + WIDTH) && args.Y >= top && args.Y < (top + height))
 			{
-				int height = (16 * _units.Length) + 6;
-				int yy = (200 - height) / 2;
-				if (args.Y >= yy && args.Y < (yy + height))
+				int y = (args.Y - top - VerticalPadding);
+				int uid = (y - (y % UnitRowHeight)) / UnitRowHeight;
+				if (uid < 0 || uid >= _units.Length)
 				{
-					int y = (args.Y - yy - 3);
-					int uid = (y - (y % 16)) / 16;
-					if (uid < 0 || uid >= _units.Length)
-						return true;
-					
-					Game.ActiveUnit = _units[uid];
-					_units[uid].Busy = false;
-                    _units[uid].Goto = System.Drawing.Point.Empty; // fire-eggs 20190612 clear Goto
+					_update = true;
 					return true;
 				}
+				
+				Game.ActiveUnit = _units[uid];
+				_units[uid].Busy = false;
+                    _units[uid].Goto = System.Drawing.Point.Empty; // fire-eggs 20190612 clear Goto
+				_update = true;
+				return true;
 			}
 
-			Destroy();
 			return true;
+		}
+		public override bool MouseDown(ScreenEventArgs args)
+		{
+			int dialogHeight = DialogHeight;
+			int dialogLeft = DialogLeft;
+			int dialogTop = DialogTop;
+
+			var outOfBounds = args.X < dialogLeft || args.X >= dialogLeft + WIDTH || args.Y < dialogTop || args.Y >= dialogTop + dialogHeight;
+			if (outOfBounds)
+			{
+				Destroy();
+				return true;
+			}
+
+			// Ignore gaps between units for easier calculation.
+			int relativeY = args.Y - dialogTop - VerticalPadding;
+			int unitIndex = relativeY / UnitRowHeight;
+
+			if (unitIndex < 0 || unitIndex >= _units.Length)
+			{
+				return true;
+			}
+
+			WakeAndSelectUnit(_units[unitIndex]);
+			_update = true;
+			return true;
+		}
+
+		private static void WakeAndSelectUnit(IUnit unit)
+		{
+			if (unit.Busy)
+			{
+				unit.Busy = false;
+				// do not reset MovesLeft, otherwise a unit that has 
+				// already moved would be able to move again after being selected from the stack
+			}
+
+			unit.Goto = Point.Empty;
+			Game.ActiveUnit = unit;
 		}
 
 		internal UnitStack(int x, int y) : base(MouseCursor.Pointer)
 		{
-			_x = x;
-			_y = y;
-			_units = Map[_x, _y].Units.Take(12).ToArray();
+			_units = Map[x, y].Units.Take(12).ToArray();
 
 			Palette = Common.TopScreen.Palette;
 		}

--- a/src/Services/Pathfinding/UnitGotoServiceImpl.cs
+++ b/src/Services/Pathfinding/UnitGotoServiceImpl.cs
@@ -110,6 +110,6 @@ namespace CivOne.Services.Pathfinding
 		}
 
 		private int DistanceToTile(int x1, int y1, int x2, int y2)
-			=> Math.Max(Math.Min(Math.Abs(x2 - x1), Math.Abs(_mapTiles.Width - (x2 - x1))), Math.Abs(y2 - y1));
+			=> Math.Max(Math.Min(Math.Abs(x2 - x1), _mapTiles.Width - Math.Abs(x2 - x1)), Math.Abs(y2 - y1));
 	}
 }

--- a/src/Services/Pathfinding/UnitGotoServiceImpl2.cs
+++ b/src/Services/Pathfinding/UnitGotoServiceImpl2.cs
@@ -189,6 +189,6 @@ namespace CivOne.Services.Pathfinding
 			=> y * mapWidth + x;
 
 		private int DistanceToTile(int x1, int y1, int x2, int y2)
-			=> Math.Max(Math.Min(Math.Abs(x2 - x1), Math.Abs(_mapTiles.Width - (x2 - x1))), Math.Abs(y2 - y1));
+			=> Math.Max(Math.Min(Math.Abs(x2 - x1), _mapTiles.Width - Math.Abs(x2 - x1)), Math.Abs(y2 - y1));
 	}
 }

--- a/src/Units/BaseUnit.cs
+++ b/src/Units/BaseUnit.cs
@@ -25,6 +25,7 @@ using CivOne.UserInterface;
 
 using CivOne.Wonders;
 using CivOne.Units;
+using CivOne.Governments;
 
 namespace CivOne.Units
 {
@@ -308,6 +309,39 @@ namespace CivOne.Units
 			return win;
 		}
 
+		private bool AllowedToConfrontInDemocracy(ITile moveTarget)
+		{
+			if (Human != Owner || Player.Government is not Governments.Democracy)
+			{
+				return true;
+			}
+
+			Player targetOwner = GetConfrontationTargetOwner(moveTarget);
+			if (targetOwner == null || targetOwner.Civilization is Barbarian || Player.IsAtWar(targetOwner))
+			{
+				return true;
+			}
+
+			GameTask.Enqueue(Message.Error("-- Civilization Note --", TextFile.Instance.GetGameText("ERROR/DEMOCRACY")));
+			return false;
+		}
+
+		private Player GetConfrontationTargetOwner(ITile moveTarget)
+		{
+			if (moveTarget == null)
+			{
+				return null;
+			}
+
+			if (moveTarget.City != null && moveTarget.City.Owner != Owner)
+			{
+				return Game.GetPlayer(moveTarget.City.Owner);
+			}
+
+			IUnit targetUnit = moveTarget.Units.FirstOrDefault(u => u.Owner != Owner);
+			return targetUnit == null ? null : Game.GetPlayer(targetUnit.Owner);
+		}
+
 		internal virtual bool Confront(int relX, int relY)
 		{
             Goto = Point.Empty;             // Cancel any goto mode when Confronting
@@ -318,10 +352,11 @@ namespace CivOne.Units
 				return false;
 			}
 
-			Movement = new MoveUnit(relX, relY);
-
 			ITile moveTarget = Map[X, Y][relX, relY];
 			if (moveTarget == null) return false;
+			if (!AllowedToConfrontInDemocracy(moveTarget)) return false;
+
+			Movement = new MoveUnit(relX, relY);
 
 			Game.RegisterHostileAction();
 			if (moveTarget.Units.Length == 0 && moveTarget.City != null && moveTarget.City.Owner != Owner)

--- a/xunit/src/CityEconomyServiceImplTests.cs
+++ b/xunit/src/CityEconomyServiceImplTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using CivOne.Buildings;
 using CivOne.Enums;
 using CivOne.Governments;
@@ -121,6 +123,51 @@ namespace CivOne.UnitTests
             int restoredExpected = city.ResourceTiles.Sum(t => city.FoodValue(t));
             Assert.Equal(restoredExpected, city.FoodTotal);
             Assert.Equal(initial, city.FoodTotal);
+        }
+
+        [Fact]
+        public void ShieldTotal_Recomputes_WhenWorkedTileShieldChangesWithinSameTurn()
+        {
+            var unit = Game.Instance.GetUnits().First(x => x.Owner == playa.Civilization.Id);
+            City city = Game.Instance.AddCity(playa, 0, unit.X, unit.Y);
+            city.Size = 4;
+            city.ResetResourceTiles();
+            playa.Government = new Monarchy();
+
+            // Prime cache and capture state hash.
+            int initialTotal = city.ShieldTotal;
+            ulong initialHash = GetCachedShieldRawStateHash(city);
+
+            ITile tile = city.ResourceTiles.First();
+            bool originalPollution = tile.Pollution;
+
+            tile.Pollution = !originalPollution;
+            int mutatedExpected = city.ResourceTiles.Sum(t => city.ShieldValue(t));
+            int mutatedActual = city.ShieldTotal;
+            ulong mutatedHash = GetCachedShieldRawStateHash(city);
+
+            Assert.Equal(mutatedExpected, mutatedActual);
+            Assert.NotEqual(initialHash, mutatedHash);
+
+            tile.Pollution = originalPollution;
+            int restoredExpected = city.ResourceTiles.Sum(t => city.ShieldValue(t));
+            int restoredActual = city.ShieldTotal;
+            ulong restoredHash = GetCachedShieldRawStateHash(city);
+
+            Assert.Equal(restoredExpected, restoredActual);
+            Assert.Equal(initialTotal, restoredActual);
+            Assert.Equal(initialHash, restoredHash);
+        }
+
+        private static ulong GetCachedShieldRawStateHash(City city)
+        {
+            var field = typeof(City).GetField("_cachedShieldRawStateHash", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+
+            object rawValue = field.GetValue(city);
+            Assert.NotNull(rawValue);
+
+            return (ulong)rawValue;
         }
 
         [Fact]


### PR DESCRIPTION
Consolidation branch for multiple issues and pull requests to save time fixing...


Issue #31 Missing: Senate blocks war declarations in Democracy government #31
Open
Issue #34 perf: extend CityEconomyBreakdown to cover food and shield tile sums Fixes ChrisWiGit/CivOne#34

[Pull request #30 ](https://github.com/ChrisWiGit/CivOne/pull/30) Wake up units from unit stack
[Pull request #27](https://github.com/ChrisWiGit/CivOne/pull/27): fix: correct DistanceToTile east-west wrap calculation
Use wrap distance formula as width - abs(dx) instead of abs(width - dx).
This fixes wrong distances when x2 < x1 and movement/targeting crosses the map edge.
Apply the same correction to shared tile distance and both goto pathfinding heuristics.
Fixes auto-travel edge crossing, AI target selection, and city distance checks.

[PR  request #29](https://github.com/ChrisWiGit/CivOne/pull/29) Fix settler AI tight loop in improvement orders
Correct road eligibility check to only select tiles needing infrastructure
Call SkipTurn after queuing road, irrigation, and mine orders
Prevent infinite re-enqueue of Turn.Move when settlers start improvements




