### PR TITLE
feat(Settings, Setup, Window): add V-sync toggle in setup menu and re…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
+* Feature: Introduced V-sync toggle in setup menu
+  * Added "V-Sync" setting in the setup menu with options "On" (default) and "Off".
+  * When V-Sync is enabled, the game synchronizes its frame rate with the display's refresh rate to prevent screen tearing.
+  * When V-Sync is disabled, the game runs at the maximum possible frame rate, which can reduce input latency but may cause screen tearing on some displays.
+  * The selected V-Sync setting is saved in the profile and applied on game startup.
 * Feature: Large maps with improved map generation
   * Map generation now supports sizes up to 1000x1000 tiles.
     Very large maps can take a long time to generate and may reduce performance.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ I did not browse all issues on github at first, so I did not recognize that some
 * Feature: Introduced V-sync toggle in setup menu
   * Added "V-Sync" setting in the setup menu with options "On" (default) and "Off".
   * When V-Sync is enabled, the game synchronizes its frame rate with the display's refresh rate to prevent screen tearing.
-  * When V-Sync is disabled, the game runs at the maximum possible frame rate, which can reduce input latency but may cause screen tearing on some displays.
+  * When V-Sync is disabled, the game runs at the maximum possible frame rate maxing out the GPU.
   * The selected V-Sync setting is saved in the profile and applied on game startup.
 * Feature: Large maps with improved map generation
   * Map generation now supports sizes up to 1000x1000 tiles.

--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ These settings affect the overall game behavior and used graphics/sound options.
 | Graphics Mode | Choose the graphics rendering mode (e.g. 256-colour or 16-colour). |
 | Aspect Ratio | Select how the game handles aspect ratio (Auto, Fixed, Scaled, ScaledFixed, Expand). |
 | Full Screen | Toggle fullscreen mode on or off (`Alt+Enter`). |
+| VSync | Synchronize rendering to the display refresh rate. This is enabled by default. It helps prevent the GPU from running at full load. Changing this setting requires a restart. |
 | Window Scale | Set the UI scale multiplier (1x to 8x) for window size. |
 | In-game sound | Browse for and enable in-game sound files. |
 

--- a/runtime/sdl/src/SDL/Window.cs
+++ b/runtime/sdl/src/SDL/Window.cs
@@ -348,7 +348,18 @@ namespace CivOne
 				if (_handle == IntPtr.Zero)
 					throw new InvalidOperationException($"SDL_CreateWindow failed: {GetSdlErrorMessage()}");
 
-				_renderer = softwareRender ? IntPtr.Zero : SDL_CreateRenderer(_handle, -1, SDL_RENDERER_FLAGS.SDL_RENDERER_ACCELERATED);
+				bool vSyncEnabled = Settings.Instance.VSync;
+				SDL_RENDERER_FLAGS rendererFlags = SDL_RENDERER_FLAGS.SDL_RENDERER_ACCELERATED;
+				if (vSyncEnabled)
+				{
+					rendererFlags |= SDL_RENDERER_FLAGS.SDL_RENDERER_PRESENTVSYNC;
+				}
+
+				_renderer = softwareRender ? IntPtr.Zero : SDL_CreateRenderer(_handle, -1, rendererFlags);
+				if (_renderer == IntPtr.Zero && !softwareRender && vSyncEnabled)
+				{
+					_renderer = SDL_CreateRenderer(_handle, -1, SDL_RENDERER_FLAGS.SDL_RENDERER_ACCELERATED);
+				}
 				if (_renderer == IntPtr.Zero)
 				{
 					_renderer = SDL_CreateRenderer(_handle, -1, SDL_RENDERER_FLAGS.SDL_RENDERER_SOFTWARE);

--- a/src/Screens/Setup.cs
+++ b/src/Screens/Setup.cs
@@ -270,6 +270,11 @@ namespace CivOne.Screens
 					.WithDescription(Translate("Resolution when using Expand ratio."))
 					.OnSelect(GotoMenu(ExpandCanvasSizeMenu)),
 			MenuItem.Create(TranslateFormatted("Full Screen: {0}", Settings.FullScreen.YesNo())).OnSelect(GotoMenu(FullScreenMenu)),
+			MenuItem.Create(TranslateFormatted("VSync: {0}", Settings.VSync.YesNo()))
+				.WithDescription(
+					Translate("Synchronize rendering to the display refresh rate."),
+					Translate("Restart the game after changing this setting."))
+				.OnSelect(GotoMenu(VSyncMenu)),
 			MenuItem.Create(TranslateFormatted("Window Size: {0}", WindowSizeText())).OnSelect(GotoMenu(WindowSizeMenu)),
 			MenuItem.Create(TranslateFormatted("Window Scale: {0}x", Settings.Scale)).OnSelect(GotoMenu(WindowScaleMenu)),
 			MenuItem.Create(Translate("In-game sound")).OnSelect(GotoMenu(SoundMenu)),
@@ -359,6 +364,20 @@ namespace CivOne.Screens
 			MenuItem.Create(Translate("Back"))
 		);
 
+		private void VSyncMenu() => CreateMenu(Translate("VSync"), GotoMenu(SettingsMenu, 6),
+			MenuItem.Create(TranslateFormatted("{0} (default)", true.YesNo()))
+				.WithDescription(
+					Translate("Synchronize rendering to the display refresh rate."),
+					Translate("Requires a restart to take effect."))
+				.OnSelect((s, a) => Settings.VSync = true).SetActive(() => Settings.VSync),
+			MenuItem.Create(false.YesNo())
+				.WithDescription(
+					Translate("Render without display synchronization."),
+					Translate("Requires a restart to take effect."))
+				.OnSelect((s, a) => Settings.VSync = false).SetActive(() => !Settings.VSync),
+			MenuItem.Create(Translate("Back"))
+		);
+
 		private string WindowSizeText() => SizeText(Settings.WindowWidth, Settings.WindowHeight, Translate("Auto"));
 
 		private void SetWindowSizePreset(int width, int height)
@@ -369,13 +388,13 @@ namespace CivOne.Screens
 
 		private void WindowSizeMenu() => CreateMenu(
 			Translate("Window Size"),
-			GotoMenu(SettingsMenu, 6),
+			GotoMenu(SettingsMenu, 7),
 			BuildSizeMenuItems(
 				WindowSizeOptions(),
 				(width, height) => IsActiveSize(Settings.WindowWidth, Settings.WindowHeight, width, height),
 				SetWindowSizePreset));
 
-		private void WindowScaleMenu() => CreateMenu(Translate("Window Scale"), GotoMenu(SettingsMenu, 7),
+		private void WindowScaleMenu() => CreateMenu(Translate("Window Scale"), GotoMenu(SettingsMenu, 8),
 			MenuItem.Create(Translate("1x")).OnSelect((s, a) => Settings.Scale = 1).SetActive(() => Settings.Scale == 1),
 			MenuItem.Create(Translate("2x (default)")).OnSelect((s, a) => Settings.Scale = 2).SetActive(() => Settings.Scale == 2),
 			MenuItem.Create(Translate("3x")).OnSelect((s, a) => Settings.Scale = 3).SetActive(() => Settings.Scale == 3),
@@ -387,7 +406,7 @@ namespace CivOne.Screens
 			MenuItem.Create(Translate("Back"))
 		);
 
-		private void SoundMenu() => CreateMenu(Translate("In-game sound"), GotoMenu(SettingsMenu, 8),
+		private void SoundMenu() => CreateMenu(Translate("In-game sound"), GotoMenu(SettingsMenu, 9),
 			MenuItem.Create(Translate("Browse for files...")).OnSelect(BrowseForSoundFiles).SetEnabled(!FileSystem.SoundFilesExist()).SetEnabled(!Game.Started),
 			MenuItem.Create(Translate("Back"))
 		);

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -61,6 +61,7 @@ namespace CivOne
 		private int _scale = 2;
 		private AspectRatio _aspectRatio = AspectRatio.Expand;
 		private int _expandWidth, _expandHeight;
+		private bool _vSync = true;
 		private bool _revealWorld = false;
 		private bool _debugMenu = false;
 		private bool _deityEnabled = false;
@@ -266,6 +267,17 @@ namespace CivOne
 				_expandHeight = value;
 				string saveValue = ((int)_expandHeight).ToString();
 				SetSetting("ExpandHeight", saveValue);
+				Common.ReloadSettings = true;
+			}
+		}
+
+		internal bool VSync
+		{
+			get => _vSync;
+			set
+			{
+				_vSync = value;
+				SetSetting("VSync", _vSync ? "1" : "0");
 				Common.ReloadSettings = true;
 			}
 		}
@@ -715,6 +727,15 @@ namespace CivOne
 			{
 				_expandWidth = -1;
 				_expandHeight = -1;
+			}
+			string vSyncSetting = GetSetting("VSync");
+			if (vSyncSetting == null)
+			{
+				SetSetting("VSync", "1");
+			}
+			else
+			{
+				_vSync = (vSyncSetting == "1");
 			}
 			GetSetting("RevealWorld", ref _revealWorld);
 			GetSetting("DebugMenu", ref _debugMenu);


### PR DESCRIPTION
* Feature: Introduced V-sync toggle in setup menu
  * Added "V-Sync" setting in the setup menu with options "On" (default) and "Off".
  * When V-Sync is enabled, the game synchronizes its frame rate with the display's refresh rate to prevent screen tearing.
  * When V-Sync is disabled, the game runs at the maximum possible frame rate maxing out the GPU.
  * The selected V-Sync setting is saved in the profile and applied on game startup.