### PR TITLE
fix(City): correct resource tile mapping and ensure full size allocation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ I did not browse all issues on github at first, so I did not recognize that some
 
 ## History
 
+* Fix: Corrected city resource tile save/load mapping and growth allocation.
+  * Fixed the savegame bit mapping so the inner northeast tile `(1,-1)` no longer collides with the outer northeast tile `(2,-1)` (only for sve savegames).
+  * `SetResourceTiles()` now keeps adding tiles until the city reaches its full size, preventing missing worked tiles from being turned into entertainers.
 * Feature: Introduced V-sync toggle in setup menu
   * Added "V-Sync" setting in the setup menu with options "On" (default) and "Off".
   * When V-Sync is enabled, the game synchronizes its frame rate with the display's refresh rate to prevent screen tearing.

--- a/src/City.cs
+++ b/src/City.cs
@@ -768,7 +768,7 @@ namespace CivOne
 				_resourceTiles.RemoveRange(Size, _resourceTiles.Count - Size);
 			}
 
-			while (_resourceTiles.Count < Size)
+			for (int index = _resourceTiles.Count; index < Size; index++)
 			{
 				// CW: must recalculate due to tile removal
 				var resourceTiles = ResourceTiles;
@@ -779,8 +779,14 @@ namespace CivOne
 					.ThenByDescending(TradeValue)
 					.FirstOrDefault();
 
-				if (bestTile != null)
-					_resourceTiles.Add(bestTile);
+				if (bestTile == null)
+				{
+					// No free worked tile left; stop here to avoid an infinite loop.
+					// A city may stay underfilled in this edge case, but that is safer than hanging.
+					break;
+				}
+
+				_resourceTiles.Add(bestTile);
 			}
 
 			UpdateSpecialists();

--- a/src/City.cs
+++ b/src/City.cs
@@ -716,7 +716,7 @@ namespace CivOne
 						continue;
 					case 1:
 						if (y == -2) output[1] |= (byte)(0x01 << 5);
-						if (y == -1) output[1] |= (byte)(0x01 << 6);
+						if (y == -1) output[0] |= (byte)(0x01 << 4);
 						if (y == 0) output[0] |= (byte)(0x01 << 1);
 						if (y == 1) output[0] |= (byte)(0x01 << 5);
 						if (y == 2) output[2] |= (byte)(0x01 << 0);
@@ -768,7 +768,7 @@ namespace CivOne
 				_resourceTiles.RemoveRange(Size, _resourceTiles.Count - Size);
 			}
 
-			if (_resourceTiles.Count < Size)
+			while (_resourceTiles.Count < Size)
 			{
 				// CW: must recalculate due to tile removal
 				var resourceTiles = ResourceTiles;

--- a/xunit/src/CityResourceTilesTests.cs
+++ b/xunit/src/CityResourceTilesTests.cs
@@ -35,12 +35,47 @@ namespace CivOne.src
 			Assert.Equal(city.Size + 1, city.ResourceTiles.Length);
 		}
 
+		[Fact]
+		public void SizeIncreaseStopsWhenNoMoreTilesAvailable()
+		{
+			var unit = Game.Instance.GetUnits().First(x => x.Owner == playa.Civilization.Id);
+			City city = Game.Instance.AddCity(playa, 1, unit.X, unit.Y);
+
+			city.Size = 30;
+
+			Assert.True(city.ResourceTiles.Length <= 21);
+		}
+
+		[Fact]
+		public void SetResourceTilesBreaksWhenNoBestTileExists()
+		{
+			var unit = Game.Instance.GetUnits().First(x => x.Owner == playa.Civilization.Id);
+			City city = Game.Instance.AddCity(playa, 1, unit.X, unit.Y);
+
+			city.Size = 30;
+			SetResourceTiles(city, []);
+
+			InvokePrivateSetResourceTiles(city);
+
+			// This map position exposes only 8 workable surrounding tiles.
+			// When those are filled, bestTile becomes null and the loop must stop.
+			Assert.Equal(9, city.ResourceTiles.Length);
+		}
+
 		private static void SetResourceTiles(City city, List<ITile> resourceTiles)
 		{
 			var field = typeof(City).GetField("_resourceTiles", BindingFlags.Instance | BindingFlags.NonPublic);
 			Assert.NotNull(field);
 
 			field.SetValue(city, resourceTiles);
+		}
+
+		private static void InvokePrivateSetResourceTiles(City city)
+		{
+			var method = typeof(City).GetMethod("SetResourceTiles", BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.NotNull(method);
+
+			method.Invoke(city, null);
 		}
 	}
 }

--- a/xunit/src/CityResourceTilesTests.cs
+++ b/xunit/src/CityResourceTilesTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using CivOne.Tiles;
+using Xunit;
+
+namespace CivOne.src
+{
+	public class CityResourceTilesTests : TestsBase
+	{
+		[Fact]
+		public void GetResourceTilesRoundTripsInnerAndOuterNorthEastTiles()
+		{
+			var unit = Game.Instance.GetUnits().First(x => x.Owner == playa.Civilization.Id);
+			City city = Game.Instance.AddCity(playa, 1, unit.X, unit.Y);
+
+			SetResourceTiles(city, [city.Tile[1, -1], city.Tile[2, -1]]);
+
+			byte[] data = city.GetResourceTiles();
+			List<ITile> restored = new CityLoadGame().GetResourceTilesFromGameData(city, data);
+
+			Assert.Contains(restored, tile => tile.X == city.X + 1 && tile.Y == city.Y - 1);
+			Assert.Contains(restored, tile => tile.X == city.X + 2 && tile.Y == city.Y - 1);
+			Assert.Equal(2, restored.Count);
+		}
+
+		[Fact]
+		public void SizeIncreaseFillsAllMissingResourceTiles()
+		{
+			var unit = Game.Instance.GetUnits().First(x => x.Owner == playa.Civilization.Id);
+			City city = Game.Instance.AddCity(playa, 1, unit.X, unit.Y);
+
+			city.Size = 4;
+
+			Assert.Equal(city.Size + 1, city.ResourceTiles.Length);
+		}
+
+		private static void SetResourceTiles(City city, List<ITile> resourceTiles)
+		{
+			var field = typeof(City).GetField("_resourceTiles", BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.NotNull(field);
+
+			field.SetValue(city, resourceTiles);
+		}
+	}
+}


### PR DESCRIPTION
* Fix: Corrected city resource tile save/load mapping and growth allocation.
  * Fixed the savegame bit mapping so the inner northeast tile `(1,-1)` no longer collides with the outer northeast tile `(2,-1)` (only for sve savegames).
  * `SetResourceTiles()` now keeps adding tiles until the city reaches its full size, preventing missing worked tiles from being turned into entertainers.