### PR TITLE
Fix off-by-one in GetPlayer bounds check (out-of-bounds access)

### DIFF
--- a/src/Game.cs
+++ b/src/Game.cs
@@ -294,7 +294,7 @@ namespace CivOne
 
 		public Player GetPlayer(byte number)
 		{
-			if (_players.Length < number)
+			if (number >= _players.Length)
 				return null;
 			return _players[number];
 		}


### PR DESCRIPTION
### Problem
`Game.GetPlayer(byte number)` guards with `if (_players.Length < number)`. When `number == _players.Length` — one past the last valid index — the condition is false, so it falls through to `_players[number]` and throws `IndexOutOfRangeException` instead of returning `null`.

### Fix
Use `if (number >= _players.Length)`, so any index outside `0.._players.Length-1` returns `null` as the method intends.

### Notes
One-line change; builds clean (0 errors). Found while comparing engine fixes across a sibling CivOne fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)