### PR TITLE
Fix disaster RNG off-by-ones (last option never selected)

### DIFF
--- a/src/City.cs
+++ b/src/City.cs
@@ -1399,7 +1399,7 @@ namespace CivOne
 					if (!hillsNearby || !buildingsOtherThanPalace.Any())
 						return;
 
-					IBuilding buildingToDestroy = buildingsOtherThanPalace[Common.Random.Next(0, buildingsOtherThanPalace.Count - 1)];
+					IBuilding buildingToDestroy = buildingsOtherThanPalace[Common.Random.Next(0, buildingsOtherThanPalace.Count)];
 					RemoveBuilding(buildingToDestroy);
 
 					message.Add(TranslateFormatted("Earthquake in {0}!", Name));
@@ -1486,7 +1486,7 @@ namespace CivOne
 
 					if (buildingsOtherThanPalace.Any() && !hasAqueduct && hasConstruction)
 					{
-						IBuilding buildingToDestroy = buildingsOtherThanPalace[Common.Random.Next(0, buildingsOtherThanPalace.Count - 1)];
+						IBuilding buildingToDestroy = buildingsOtherThanPalace[Common.Random.Next(0, buildingsOtherThanPalace.Count)];
 						RemoveBuilding(buildingToDestroy);
 
 						message.Add(TranslateFormatted("Fire in {0}!", Name));
@@ -1519,7 +1519,7 @@ namespace CivOne
 					// Riot, scandal, corruption
 
 					string[] disasterTypes = { "Scandal", "Riot", "Corruption" };
-					string disasterType = disasterTypes[Common.Random.Next(0, disasterTypes.Length - 1)];
+					string disasterType = disasterTypes[Common.Random.Next(0, disasterTypes.Length)];
 					string buildingDemanded = "";
 					CitizenTypes citizenTypes = GetCitizenTypes();
 


### PR DESCRIPTION
### Problem
`Random.Next(min, max)` has an **exclusive** upper bound, so `Next(0, n - 1)` only ever returns `0 .. n-2` — the last element is unreachable. Three spots in `City.cs` use this pattern:

- **Disorder disaster picker** (`disasterTypes[Next(0, disasterTypes.Length - 1)]`): the array is `{ "Scandal", "Riot", "Corruption" }`, so `Next(0, 2)` returns only 0 or 1 — **"Corruption" never occurs.**
- **Earthquake** and **fire** building destruction (`buildingsOtherThanPalace[Next(0, Count - 1)]`): the **last building in the list can never be destroyed.**

### Fix
Drop the `- 1` in all three so the full range is reachable (`Next(0, Length)` / `Next(0, Count)`).

### Notes
Three-line change; builds clean (0 errors). Found while comparing engine fixes across a sibling CivOne fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)