### PR TITLE
Charge the city's owner (not Game.CurrentPlayer) on buy/sell

### DIFF
--- a/src/City.cs
+++ b/src/City.cs
@@ -930,9 +930,9 @@ namespace CivOne
 			int buyPrice = BuyPrice;
 			if (buyPrice <= 0) return false;
 			if (IsRiot && CurrentProduction is IBuilding) return false;
-			if (Game.CurrentPlayer.Gold < buyPrice) return false;
+			if (Player.Gold < buyPrice) return false;
 
-			Game.CurrentPlayer.Gold -= (short)buyPrice;
+			Player.Gold -= (short)buyPrice;
 			Shields = (int)CurrentProduction.Price * 10;
 			return true;
 		}
@@ -1062,7 +1062,7 @@ namespace CivOne
 		public void SellBuilding(IBuilding building)
 		{
 			RemoveBuilding(building);
-			Game.CurrentPlayer.Gold += building.SellPrice;
+			Player.Gold += building.SellPrice;
 			BuildingSold = true;
 		}
 


### PR DESCRIPTION
### Problem
`City.Buy()` and `City.SellBuilding()` read and write `Game.CurrentPlayer.Gold`. On the normal human-turn city screen the current player *is* the city's owner, so this is correct in practice today. But it is a latent hazard: if either screen is ever opened or driven during another player's turn processing, the gold is deducted from — or credited to — the wrong treasury.

### Fix
Use the city's own owner via the existing `Player` accessor (`Game.GetPlayer(Owner)`), so the buy cost and sell proceeds always hit the owner's gold regardless of whose turn it is. No behaviour change on the current call paths.

### Notes
Hardening rather than an active bug. Builds clean (0 errors). Found while comparing engine fixes across a sibling CivOne fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
