### PR TITLE
Guard possibly-null dereferences in Game.cs / City.cs (nullable CS8602)

### DIFF
--- a/src/City.cs
+++ b/src/City.cs
@@ -1125,7 +1125,7 @@ namespace CivOne
 			if (partType != SpaceShipComponentType.Empty && canShowInstallScreen)
 			{
 				Shields = 0;
-				Message message = Message.Newspaper(this, TranslateFormattedArray("{0} builds\n{1}.", this.Name, (CurrentProduction as ICivilopedia).TranslatedName));
+				Message message = Message.Newspaper(this, TranslateFormattedArray("{0} builds\n{1}.", this.Name, (CurrentProduction as ICivilopedia)?.TranslatedName));
 				message.Done += (s, a) =>
 				{
 					Show showSpaceShip = Show.SpaceShipWithInstall(partType);
@@ -1157,7 +1157,7 @@ namespace CivOne
 			}
 			_buildings.Add(CurrentProduction as IBuilding);
 
-			Message message = Message.Newspaper(this, TranslateFormattedArray("{0} builds\n{1}.", this.Name, (CurrentProduction as ICivilopedia).TranslatedName));
+			Message message = Message.Newspaper(this, TranslateFormattedArray("{0} builds\n{1}.", this.Name, (CurrentProduction as ICivilopedia)?.TranslatedName));
 			message.Done += (s, a) =>
 			{
 				GameTask advisorMessage = Message.Advisor(Advisor.Foreign, true, $"{Player.TribeName} capital", $"moved to {Name}.");
@@ -1324,10 +1324,10 @@ namespace CivOne
 				{
 					// On Chieftain level, it's not possible to create a Settlers in a city of size 1
 				}
-				else if (CurrentProduction is IUnit)
+				else if (CurrentProduction is IUnit currentUnit)
 				{
 					Shields = 0;
-					IUnit unit = Game.Instance.CreateUnit((CurrentProduction as IUnit).Type, X, Y, Owner);
+					IUnit unit = Game.Instance.CreateUnit(currentUnit.Type, X, Y, Owner);
 					unit.SetHome();
 					unit.Veteran = _buildings.Any(b => b is Barracks);
 					if (CurrentProduction is Settlers)
@@ -1346,17 +1346,17 @@ namespace CivOne
 						GameTask.Enqueue(advisorMessage);
 					}
 				}
-				if (CurrentProduction is IBuilding && !_buildings.Any(b => b.Id == (CurrentProduction as IBuilding).Id) && !HandleSpaceShipProduction() && !HandlePalaceBuilding())
+				if (CurrentProduction is IBuilding currentBuilding && !_buildings.Any(b => b.Id == currentBuilding.Id) && !HandleSpaceShipProduction() && !HandlePalaceBuilding())
 				{
 					Shields = 0;
-					_buildings.Add(CurrentProduction as IBuilding);
-					GameTask.Enqueue(new ImprovementBuilt(this, CurrentProduction as IBuilding));
+					_buildings.Add(currentBuilding);
+					GameTask.Enqueue(new ImprovementBuilt(this, currentBuilding));
 				}
-				if (CurrentProduction is IWonder && !Game.Instance.BuiltWonders.Any(w => w.Id == (CurrentProduction as IWonder).Id))
+				if (CurrentProduction is IWonder currentWonder && !Game.Instance.BuiltWonders.Any(w => w.Id == currentWonder.Id))
 				{
 					Shields = 0;
-					AddWonder(CurrentProduction as IWonder);
-					GameTask.Enqueue(new ImprovementBuilt(this, CurrentProduction as IWonder));
+					AddWonder(currentWonder);
+					GameTask.Enqueue(new ImprovementBuilt(this, currentWonder));
 				}
 			}
 

--- a/src/Game.cs
+++ b/src/Game.cs
@@ -241,6 +241,7 @@ namespace CivOne
 		private void PlayerDestroyed(object sender, EventArgs args)
 		{
 			Player player = (sender as Player);
+			if (player is null) return;
 
 			ICivilization destroyed = player.Civilization;
 			ICivilization destroyedBy = Game.CurrentPlayer.Civilization;
@@ -935,8 +936,8 @@ namespace CivOne
 				if (isSettlers)
 				{
 					// Cancel order if settler is set active
-					var settler = toActivateUnit as Settlers;
-					settler.ResetOrder();
+					if (toActivateUnit is Settlers settler)
+						settler.ResetOrder();
 				}
 
 				if (isSentryOrFortify && isAlreadyMoved)


### PR DESCRIPTION
### Context
With `<Nullable>enable</Nullable>` the compiler flags CS8602 ("dereference of a possibly null reference"). This PR clears the CS8602 cluster in the two core engine files (`Game.cs`, `City.cs`). All changes are behaviour-neutral.

### Changes
- **`PlayerDestroyed`** — `(sender as Player)` could be null; return early instead of dereferencing it.
- **`City.NewTurn` production completion** — replaced the repeated `(CurrentProduction as IUnit/IBuilding/IWonder).X` with pattern matching (`is IUnit currentUnit`, etc.). The cast now happens once and is provably non-null, which is both warning-clean and a touch more efficient.
- **"City builds X" messages** (spaceship part, palace) — `(CurrentProduction as ICivilopedia)?.TranslatedName`.
- **Unit activation** — `if (toActivateUnit is Settlers settler) settler.ResetOrder();` instead of an unguarded `as` cast.

### Result
- Builds clean — **0 errors**, no new errors introduced.
- CS8602 in `Game.cs`/`City.cs` drops from ~20 occurrences to 2.

### Left for a follow-up
Two logically-safe casts remain in `Game.cs` (`(unit as BaseUnit).MoveTargets` and the boarding-cargo `unit.Tile.Units` / `(u as IBoardable)` LINQ). They can't be null on current call paths and need a bit more restructuring; I left them rather than over-touch a hot path.

### Context
Part of a sweep comparing engine fixes across a sibling CivOne fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
